### PR TITLE
Move server from main to the s3api package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/YaleSpinup/s3-api
 
 require (
-	github.com/aws/aws-sdk-go v1.16.32
+	github.com/aws/aws-sdk-go v1.16.33
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/gorilla/handlers v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/aws/aws-sdk-go v1.16.26 h1:GWkl3rkRO/JGRTWoLLIqwf7AWC4/W/1hMOUZqmX0js
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.16.32 h1:/grHp+bt3OAVWkdCQv2YtXkWuu58SuTlH1U8tp25n1c=
 github.com/aws/aws-sdk-go v1.16.32/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.16.33 h1:jXrsqeNbpLkM4TrnZbtr+4k4x7frwcLP3DiWMa7NOtE=
+github.com/aws/aws-sdk-go v1.16.33/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -88,6 +90,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 h1:bfLnR+k0tq5Lqt6dflRLcZiz6UaXCMt3vhYJ1l4FQ80=
 golang.org/x/net v0.0.0-20190206173232-65e2d4e15006/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/main.go
+++ b/main.go
@@ -6,18 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/YaleSpinup/s3-api/common"
-	"github.com/YaleSpinup/s3-api/iam"
-	"github.com/YaleSpinup/s3-api/s3"
 	"github.com/YaleSpinup/s3-api/s3api"
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
 
 	log "github.com/sirupsen/logrus"
-
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -27,24 +20,15 @@ var (
 	// VersionPrerelease is a prerelease marker
 	VersionPrerelease = s3api.VersionPrerelease
 
-	// buildstamp is the timestamp the binary was built, it should be set at buildtime with ldflags
-	buildstamp = s3api.BuildStamp
+	// Buildstamp is the timestamp the binary was built, it should be set at buildtime with ldflags
+	Buildstamp = s3api.BuildStamp
 
-	// githash is the git sha of the built binary, it should be set at buildtime with ldflags
-	githash = s3api.GitHash
+	// Githash is the git sha of the built binary, it should be set at buildtime with ldflags
+	Githash = s3api.GitHash
 
 	configFileName = flag.String("config", "config/config.json", "Configuration file.")
 	version        = flag.Bool("version", false, "Display version information and exit.")
 )
-
-// AppConfig holds the configuration information for the app
-var AppConfig common.Config
-
-// S3Services is a global map of S3 services
-var S3Services = make(map[string]s3.S3)
-
-// IAMServices is a global map of IAM services
-var IAMServices = make(map[string]iam.IAM)
 
 func main() {
 	flag.Parse()
@@ -64,10 +48,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Unable to read configuration from %s.  %+v", *configFileName, err)
 	}
-	AppConfig = config
 
 	// Set the loglevel, info if it's unset
-	switch AppConfig.LogLevel {
+	switch config.LogLevel {
 	case "error":
 		log.SetLevel(log.ErrorLevel)
 	case "warn":
@@ -78,70 +61,15 @@ func main() {
 		log.SetLevel(log.InfoLevel)
 	}
 
-	if AppConfig.LogLevel == "debug" {
+	if config.LogLevel == "debug" {
 		log.Debug("Starting profiler on 127.0.0.1:6080")
 		go http.ListenAndServe("127.0.0.1:6080", nil)
 	}
+	log.Debugf("Read config: %+v", config)
 
-	log.Debugf("Read config: %+v", AppConfig)
-
-	// Create a shared S3 session
-	for name, c := range AppConfig.Accounts {
-		log.Debugf("Creating new S3 service for account '%s' with key '%s' in region '%s'", name, c.Akid, c.Region)
-		S3Services[name] = s3.NewSession(c)
-		IAMServices[name] = iam.NewSession(c)
-	}
-
-	publicURLs := map[string]string{
-		"/v1/s3/ping":    "public",
-		"/v1/s3/version": "public",
-		"/v1/s3/metrics": "public",
-	}
-
-	router := mux.NewRouter()
-	api := router.PathPrefix("/v1/s3").Subrouter()
-	api.HandleFunc("/ping", PingHandler)
-	api.HandleFunc("/version", VersionHandler)
-	api.Handle("/metrics", promhttp.Handler())
-
-	// Buckets handlers
-	api.HandleFunc("/{account}/buckets", BucketListHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/buckets", BucketCreateHandler).Methods(http.MethodPost)
-	api.HandleFunc("/{account}/buckets/{bucket}", BucketHeadHandler).Methods(http.MethodHead)
-	// api.HandleFunc("/{account}/buckets/{bucket}", BucketShowHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/buckets/{bucket}", BucketDeleteHandler).Methods(http.MethodDelete)
-	api.HandleFunc("/{account}/buckets/{bucket}/objects", ObjectCountHandler).Methods(http.MethodHead)
-
-	if AppConfig.ListenAddress == "" {
-		AppConfig.ListenAddress = ":8080"
-	}
-	handler := handlers.LoggingHandler(os.Stdout, TokenMiddleware(publicURLs, router))
-	srv := &http.Server{
-		Handler:      handler,
-		Addr:         AppConfig.ListenAddress,
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
-	}
-
-	log.Infof("Starting listener on %s", AppConfig.ListenAddress)
-
-	if err := srv.ListenAndServe(); err != nil {
+	if err := s3api.NewServer(config); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// LogWriter is an http.ResponseWriter
-type LogWriter struct {
-	http.ResponseWriter
-}
-
-// Write log message if http response writer returns and error
-func (w LogWriter) Write(p []byte) (n int, err error) {
-	n, err = w.ResponseWriter.Write(p)
-	if err != nil {
-		log.Errorf("Write failed: %v", err)
-	}
-	return
 }
 
 func vers() {

--- a/s3api/handlers.go
+++ b/s3api/handlers.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import (
 	"encoding/json"
@@ -9,7 +9,7 @@ import (
 )
 
 // PingHandler responds to ping requests
-func PingHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) PingHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	log.Debug("Ping/Pong")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -18,7 +18,7 @@ func PingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // VersionHandler responds to version requests
-func VersionHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
@@ -36,8 +36,8 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 		BuildStamp string `json:"buildstamp"`
 	}{
 		Version:    fmt.Sprintf("%s%s", Version, VersionPrerelease),
-		GitHash:    githash,
-		BuildStamp: buildstamp,
+		GitHash:    GitHash,
+		BuildStamp: BuildStamp,
 	})
 
 	if err != nil {

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import (
 	"encoding/json"
@@ -14,18 +14,18 @@ import (
 )
 
 // BucketCreateHandler creates a new s3 bucket
-func BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
-	s3Service, ok := S3Services[account]
+	s3Service, ok := s.s3Services[account]
 	if !ok {
 		log.Errorf("S3 service not found for account: %s", account)
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	iamService, ok := IAMServices[account]
+	iamService, ok := s.iamServices[account]
 	if !ok {
 		log.Errorf("IAM service not found for account: %s", account)
 		w.WriteHeader(http.StatusNotFound)
@@ -230,11 +230,11 @@ func BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // BucketListHandler gets a list of buckets
-func BucketListHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) BucketListHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
-	s3Service, ok := S3Services[account]
+	s3Service, ok := s.s3Services[account]
 	if !ok {
 		log.Errorf("account not found: %s", account)
 		w.WriteHeader(http.StatusNotFound)
@@ -268,12 +268,12 @@ func BucketListHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // BucketHeadHandler checks if a bucket exists
-func BucketHeadHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) BucketHeadHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
 	bucket := vars["bucket"]
-	s3Service, ok := S3Services[account]
+	s3Service, ok := s.s3Services[account]
 	if !ok {
 		log.Errorf("account not found: %s", account)
 		w.WriteHeader(http.StatusNotFound)
@@ -319,12 +319,12 @@ func BucketHeadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // BucketDeleteHandler deletes an empty bucket
-func BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
 	account := vars["account"]
 	bucket := vars["bucket"]
-	s3Service, ok := S3Services[account]
+	s3Service, ok := s.s3Services[account]
 	if !ok {
 		log.Errorf("account not found: %s", account)
 		w.WriteHeader(http.StatusNotFound)

--- a/s3api/handlers_buckets_test.go
+++ b/s3api/handlers_buckets_test.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import "testing"
 

--- a/s3api/handlers_objects.go
+++ b/s3api/handlers_objects.go
@@ -1,0 +1,63 @@
+package s3api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+)
+
+// ObjectCountHandler returns the count of objects as a header
+func (s *server) ObjectCountHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	bucket := vars["bucket"]
+	s3Service, ok := s.s3Services[account]
+	if !ok {
+		log.Errorf("account not found: %s", account)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	log.Infof("checking if bucket exists: %s", bucket)
+	output, err := s3Service.Service.HeadBucketWithContext(r.Context(), &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchBucket:
+				log.Errorf("bucket %s not found.", bucket)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			case "NotFound":
+				log.Errorf("bucket %s not found.", bucket)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			case "Forbidden":
+				log.Errorf("forbidden to access requested bucket %s", bucket)
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
+		log.Errorf("error checking for bucket %s: %s", bucket, err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal response (%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}

--- a/s3api/handlers_test.go
+++ b/s3api/handlers_test.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import (
 	"net/http"
@@ -12,7 +12,8 @@ func TestPingHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(PingHandler)
+	s := server{}
+	handler := http.HandlerFunc(s.PingHandler)
 
 	handler.ServeHTTP(rr, req)
 
@@ -34,7 +35,8 @@ func TestVersionHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(VersionHandler)
+	s := server{}
+	handler := http.HandlerFunc(s.VersionHandler)
 
 	handler.ServeHTTP(rr, req)
 

--- a/s3api/middleware.go
+++ b/s3api/middleware.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import (
 	"net/http"
@@ -8,7 +8,7 @@ import (
 )
 
 // TokenMiddleware checks the tokens for non-public URLs
-func TokenMiddleware(public map[string]string, h http.Handler) http.Handler {
+func TokenMiddleware(psk string, public map[string]string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Debug("Processing token middleware for protected URLs")
 
@@ -35,7 +35,7 @@ func TokenMiddleware(public map[string]string, h http.Handler) http.Handler {
 			log.Infof("Authenticating token for protected URL '%s'", r.URL)
 
 			htoken := r.Header.Get("X-Auth-Token")
-			if AppConfig.Token == htoken {
+			if psk == htoken {
 				log.Debugf("Authenticating preshared token '%s' for '%s'", htoken, r.URL)
 			} else {
 				log.Warnf("Unable to authenticate session for '%s' with '%s'", r.URL, htoken)

--- a/s3api/middleware_test.go
+++ b/s3api/middleware_test.go
@@ -1,4 +1,4 @@
-package main
+package s3api
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTokenMiddleware(t *testing.T) {
-	AppConfig.Token = "sometesttoken"
+	psk := "sometesttoken"
 
 	// Test handler that just returns 200 OK
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +23,7 @@ func TestTokenMiddleware(t *testing.T) {
 	}
 
 	// Start a new server with our token middleware and test handler
-	server := httptest.NewServer(TokenMiddleware(pubUrls, okHandler))
+	server := httptest.NewServer(TokenMiddleware(psk, pubUrls, okHandler))
 	defer server.Close()
 
 	// Test some public urls
@@ -51,7 +51,7 @@ func TestTokenMiddleware(t *testing.T) {
 	// Test a priate URL _with_ an auth-token
 	client := &http.Client{}
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/private", server.URL), nil)
-	req.Header.Add("X-Auth-Token", AppConfig.Token)
+	req.Header.Add("X-Auth-Token", psk)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/s3api/routes.go
+++ b/s3api/routes.go
@@ -1,0 +1,22 @@
+package s3api
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func (s *server) routes() {
+	api := s.router.PathPrefix("/v1/s3").Subrouter()
+	api.HandleFunc("/ping", s.PingHandler)
+	api.HandleFunc("/version", s.VersionHandler)
+	api.Handle("/metrics", promhttp.Handler())
+
+	// Buckets handlers
+	api.HandleFunc("/{account}/buckets", s.BucketListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/buckets", s.BucketCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
+	// api.HandleFunc("/{account}/buckets/{bucket}", s.BucketShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/buckets/{bucket}/objects", s.ObjectCountHandler).Methods(http.MethodHead)
+}

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -1,0 +1,78 @@
+package s3api
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/YaleSpinup/s3-api/common"
+	"github.com/YaleSpinup/s3-api/iam"
+	"github.com/YaleSpinup/s3-api/s3"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type server struct {
+	s3Services  map[string]s3.S3
+	iamServices map[string]iam.IAM
+	router      *mux.Router
+}
+
+// NewServer creates a new server and starts it
+func NewServer(config common.Config) error {
+	s := server{
+		s3Services:  make(map[string]s3.S3),
+		iamServices: make(map[string]iam.IAM),
+		router:      mux.NewRouter(),
+	}
+
+	// Create a shared S3 session
+	for name, c := range config.Accounts {
+		log.Debugf("Creating new S3 service for account '%s' with key '%s' in region '%s'", name, c.Akid, c.Region)
+		s.s3Services[name] = s3.NewSession(c)
+		s.iamServices[name] = iam.NewSession(c)
+	}
+
+	publicURLs := map[string]string{
+		"/v1/s3/ping":    "public",
+		"/v1/s3/version": "public",
+		"/v1/s3/metrics": "public",
+	}
+
+	// load routes
+	s.routes()
+
+	if config.ListenAddress == "" {
+		config.ListenAddress = ":8080"
+	}
+	handler := handlers.LoggingHandler(os.Stdout, TokenMiddleware(config.Token, publicURLs, s.router))
+	srv := &http.Server{
+		Handler:      handler,
+		Addr:         config.ListenAddress,
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+
+	log.Infof("Starting listener on %s", config.ListenAddress)
+	if err := srv.ListenAndServe(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LogWriter is an http.ResponseWriter
+type LogWriter struct {
+	http.ResponseWriter
+}
+
+// Write log message if http response writer returns and error
+func (w LogWriter) Write(p []byte) (n int, err error) {
+	n, err = w.ResponseWriter.Write(p)
+	if err != nil {
+		log.Errorf("Write failed: %v", err)
+	}
+	return
+}


### PR DESCRIPTION
This is the move from `main` to the `s3api` sub package.  It's safe to ignore `s3api/handlers_objects.go`, I added it by mistake.  I can delete it if its distracting, but I will update it and add functionality to it later.