### PR TITLE
Standardize errors and build rollback for bucket creation

### DIFF
--- a/apierror/error.go
+++ b/apierror/error.go
@@ -1,0 +1,59 @@
+package apierror
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrBadRequest indicates a bad request or input
+const ErrBadRequest = "BadRequest"
+
+// ErrForbidden indicates a lack of permissions for the given resource
+const ErrForbidden = "Forbidden"
+
+// ErrNotFound indicates a the requested object is missing/not found
+const ErrNotFound = "NotFound"
+
+// ErrConflict indicates a conflict with an existing resource
+const ErrConflict = "Conflict"
+
+// ErrLimitExceeded indicates a service or rate limit has been exceeded
+const ErrLimitExceeded = "LimitExceeded"
+
+// ErrServiceUnavailable indicates an internal or external service is not available
+const ErrServiceUnavailable = "ServiceUnavailable"
+
+// ErrInternalError indicates an unknown internal error occurred
+const ErrInternalError = "InternalError"
+
+// Error wraps lower level errors with code, message and an original error.  This is
+// modelled after the awserr with the intention of standardizing the output.
+type Error struct {
+	Code    string
+	Message string
+	OrigErr error
+}
+
+// New constructs an Error and returns it as an error
+func New(code, message string, err error) Error {
+	origErr := err
+	if err == nil {
+		origErr = errors.New("")
+	}
+
+	return Error{
+		Code:    code,
+		Message: message,
+		OrigErr: origErr,
+	}
+}
+
+// Error Satisfies the Error interface
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.OrigErr.Error())
+}
+
+// String returns the error as string
+func (e Error) String() string {
+	return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.OrigErr.Error())
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ require (
 	github.com/aws/aws-sdk-go v1.16.33
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gogo/protobuf v1.2.0 // indirect
+	github.com/google/pprof v0.0.0-20190208070709-b421f19a5c07 // indirect
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v1.7.0
+	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
@@ -13,6 +15,7 @@ require (
 	github.com/prometheus/procfs v0.0.0-20190209105433-f8d8b3f739bd // indirect
 	github.com/sirupsen/logrus v1.3.0
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,12 +25,16 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/pprof v0.0.0-20190208070709-b421f19a5c07 h1:a8gLxYPNyi4nj8mRSyv71dzsQgGDEOo4Fg4nWcyUBto=
+github.com/google/pprof v0.0.0-20190208070709-b421f19a5c07/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZsA=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.0 h1:tOSd0UKHQd6urX6ApfOn4XdBMY6Sh1MfxV3kmaazO+U=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -78,6 +82,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 h1:Pn8fQdvx+z1avAi7fdM2kRYWQNxGlavNDSyzrQg2SsU=
+golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ56NFcDtcBNkYP7yv8YbUE=

--- a/iam/groups.go
+++ b/iam/groups.go
@@ -1,0 +1,148 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YaleSpinup/s3-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	log "github.com/sirupsen/logrus"
+)
+
+// CreateGroup handles creating an IAM group
+func (i *IAM) CreateGroup(ctx context.Context, input *iam.CreateGroupInput) (*iam.CreateGroupOutput, error) {
+	log.Infof("creating IAM group: %s", aws.StringValue(input.GroupName))
+	output, err := i.Service.CreateGroupWithContext(ctx, input)
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeEntityAlreadyExistsException "EntityAlreadyExists"
+			// The request was rejected because it attempted to create a resource that already
+			// exists.
+			case iam.ErrCodeEntityAlreadyExistsException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeNoSuchEntityException "NoSuchEntity"
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			case iam.ErrCodeNoSuchEntityException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}
+
+// DeleteGroup handles deleting an IAM group
+func (i *IAM) DeleteGroup(ctx context.Context, input *iam.DeleteGroupInput) (*iam.DeleteGroupOutput, error) {
+	if input == nil || aws.StringValue(input.GroupName) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting iam group %s", aws.StringValue(input.GroupName))
+
+	output, err := i.Service.DeleteGroupWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeNoSuchEntityException "NoSuchEntity"
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			case iam.ErrCodeNoSuchEntityException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrNotFound, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeDeleteConflictException "DeleteConflict"
+			// The request was rejected because it attempted to delete a resource that has
+			// attached subordinate entities. The error message describes these entities.
+			case iam.ErrCodeDeleteConflictException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}
+
+func (i *IAM) AttachGroupPolicy(ctx context.Context, input *iam.AttachGroupPolicyInput) (*iam.AttachGroupPolicyOutput, error) {
+	if input == nil || aws.StringValue(input.GroupName) == "" || aws.StringValue(input.PolicyArn) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	output, err = i.Service.AttachGroupPolicyWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeNoSuchEntityException "NoSuchEntity"
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			case iam.ErrCodeNoSuchEntityException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrNotFound, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeInvalidInputException "InvalidInput"
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			// * ErrCodePolicyNotAttachableException "PolicyNotAttachable"
+			// The request failed because AWS service role policies can only be attached
+			// to the service-linked role for that service.
+			case iam.ErrCodeInvalidInputException, iam.ErrCodePolicyNotAttachableException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}

--- a/iam/groups.go
+++ b/iam/groups.go
@@ -105,7 +105,7 @@ func (i *IAM) AttachGroupPolicy(ctx context.Context, input *iam.AttachGroupPolic
 		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
 	}
 
-	output, err = i.Service.AttachGroupPolicyWithContext(ctx, input)
+	output, err := i.Service.AttachGroupPolicyWithContext(ctx, input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {

--- a/iam/policy.go
+++ b/iam/policy.go
@@ -1,0 +1,110 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YaleSpinup/s3-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	log "github.com/sirupsen/logrus"
+)
+
+// CreatePolicy handles creating IAM policy
+func (i *IAM) CreatePolicy(ctx context.Context, input *iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
+	log.Infof("creating iam policy: %s", *input.PolicyName)
+
+	output, err := i.Service.CreatePolicyWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeInvalidInputException "InvalidInput"
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			// * ErrCodeMalformedPolicyDocumentException "MalformedPolicyDocument"
+			// The request was rejected because the policy document was malformed. The error
+			// message describes the specific error.
+			case iam.ErrCodeInvalidInputException, iam.ErrCodeMalformedPolicyDocumentException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeEntityAlreadyExistsException "EntityAlreadyExists"
+			// The request was rejected because it attempted to create a resource that already
+			// exists.
+			case iam.ErrCodeEntityAlreadyExistsException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}
+
+// DeletePolicy handles deleting IAM policy
+func (i *IAM) DeletePolicy(ctx context.Context, input *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
+	if input == nil || aws.StringValue(input.PolicyArn) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting iam policy %s", aws.StringValue(input.PolicyArn))
+
+	output, err := i.Service.DeletePolicyWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			// * ErrCodeNoSuchEntityException "NoSuchEntity"
+			// The request was rejected because it referenced a resource entity that does
+			// not exist. The error message describes the resource.
+			case iam.ErrCodeNoSuchEntityException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrNotFound, msg, err)
+			// * ErrCodeLimitExceededException "LimitExceeded"
+			// The request was rejected because it attempted to create resources beyond
+			// the current AWS account limits. The error message describes the limit exceeded.
+			case iam.ErrCodeLimitExceededException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrLimitExceeded, msg, err)
+			// * ErrCodeInvalidInputException "InvalidInput"
+			// The request was rejected because an invalid or out-of-range value was supplied
+			// for an input parameter.
+			case iam.ErrCodeInvalidInputException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrBadRequest, msg, err)
+			// * ErrCodeDeleteConflictException "DeleteConflict"
+			// The request was rejected because it attempted to delete a resource that has
+			// attached subordinate entities. The error message describes these entities.
+			case iam.ErrCodeDeleteConflictException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			// * ErrCodeServiceFailureException "ServiceFailure"
+			// The request processing has failed because of an unknown error, exception
+			// or failure.
+			case iam.ErrCodeServiceFailureException:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrServiceUnavailable, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -1,0 +1,73 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YaleSpinup/s3-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	log "github.com/sirupsen/logrus"
+)
+
+// CreateBucket handles checking if a bucket exists and creating it
+func (s *S3) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	log.Infof("creating bucket: %s", aws.StringValue(input.Bucket))
+
+	// Checks if a bucket exists in the account heading it.  This is a bit of a hack since in
+	// us-east-1 (only) bucket creation will succeed if the bucket already exists in your
+	// account.  In all other regions, the API will return s3.ErrCodeBucketAlreadyOwnedByYou 🤷‍♂️
+	if _, err := s.Service.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
+		Bucket: input.Bucket,
+	}); err == nil {
+		return nil, apierror.New(apierror.ErrConflict, "bucket exists and is owned by you", nil)
+	}
+
+	output, err := s.Service.CreateBucketWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeBucketAlreadyExists, s3.ErrCodeBucketAlreadyOwnedByYou:
+				msg := fmt.Sprintf("%s: %s", aerr.Code(), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			default:
+				return nil, apierror.New(apierror.ErrBadRequest, aerr.Message(), err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, nil
+}
+
+// DeleteEmptyBucket handles deleting an empty bucket
+func (s *S3) DeleteEmptyBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	if input == nil || aws.StringValue(input.Bucket) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting bucket: %s", aws.StringValue(input.Bucket))
+
+	output, err := s.Service.DeleteBucketWithContext(ctx, input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchBucket, "NotFound":
+				msg := fmt.Sprintf("bucket %s not found: %s", aws.StringValue(input.Bucket), aerr.Error())
+				return nil, apierror.New(apierror.ErrNotFound, msg, err)
+			case "BucketNotEmpty":
+				msg := fmt.Sprintf("trying to delete bucket %s that is not empty: %s", aws.StringValue(input.Bucket), aerr.Error())
+				return nil, apierror.New(apierror.ErrConflict, msg, err)
+			case "Forbidden":
+				msg := fmt.Sprintf("forbidden to access requested bucket %s: %s", aws.StringValue(input.Bucket), aerr.Error())
+				return nil, apierror.New(apierror.ErrForbidden, msg, err)
+			}
+		}
+
+		return nil, apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
+	}
+
+	return output, err
+}

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -285,27 +285,3 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(j)
 }
-
-func handleError(w http.ResponseWriter, err error) {
-	log.Error(err.Error())
-	if aerr, ok := err.(apierror.Error); ok {
-		switch aerr.Code {
-		case apierror.ErrForbidden:
-			w.WriteHeader(http.StatusForbidden)
-		case apierror.ErrNotFound:
-			w.WriteHeader(http.StatusNotFound)
-		case apierror.ErrConflict:
-			w.WriteHeader(http.StatusConflict)
-		case apierror.ErrBadRequest:
-			w.WriteHeader(http.StatusBadRequest)
-		case apierror.ErrLimitExceeded:
-			w.WriteHeader(http.StatusTooManyRequests)
-		default:
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		w.Write([]byte(aerr.Message))
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
-	}
-}

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -47,7 +47,7 @@ func NewServer(config common.Config) error {
 	if config.ListenAddress == "" {
 		config.ListenAddress = ":8080"
 	}
-	handler := handlers.LoggingHandler(os.Stdout, TokenMiddleware(config.Token, publicURLs, s.router))
+	handler := handlers.RecoveryHandler()(handlers.LoggingHandler(os.Stdout, TokenMiddleware(config.Token, publicURLs, s.router)))
 	srv := &http.Server{
 		Handler:      handler,
 		Addr:         config.ListenAddress,


### PR DESCRIPTION
This standardizes our errors in the `apierror` package so we don't have to case/switch for a handful of different AWS errors for every call to the API.  It also centralizes handling those errors.  Finally, it implements a rollback stack that gets appended to and processed on failure.