### PR TITLE
Add support for tagging on creation, getting bucket details and updating bucket details

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,30 @@ POST `/v1/s3/{account}/buckets
 | **500 Internal Server Error** | a server error occurred              |
 | **503 Service Unavailable**   | an AWS service is unavailable        |
 
+### Update a bucket
+
+Updating a bucket currently only supports updating the bucket's tags
+
+POST `/v1/s3/{account}/buckets/foobarbucketname`
+
+#### Request
+
+```json
+{
+    "Tags": {
+        "Application": "HowToGet",
+        "COA": "Take.My.Money.$$$$",
+        "CreatedBy": "Big Bird"
+    }
+}
+```
+
+| Response Code                 | Definition                      |  
+| ----------------------------- | --------------------------------|  
+| **200 OK**                    | deleted bucket                  |  
+| **400 Bad Request**           | badly formed request            |  
+| **500 Internal Server Error** | a server error occurred         |
+
 ### Check if a bucket exists
 
 HEAD `/v1/s3/{account}/buckets/foobarbucketname`
@@ -169,6 +193,18 @@ HEAD `/v1/s3/{account}/buckets/foobarbucketname`
 | **200 OK**                    | bucket exists                   |  
 | **403 Forbidden**             | you don't have access to bucket |  
 | **404 Not Found**             | account or bucket not found     |  
+| **500 Internal Server Error** | a server error occurred         |
+
+### Get information for a bucket
+
+Getting details about a bucket currently only returns tagging information
+
+GET `/v1/s3/{account}/buckets/foobarbucketname`
+
+| Response Code                 | Definition                      |  
+| ----------------------------- | --------------------------------|  
+| **200 OK**                    | deleted bucket                  |  
+| **400 Bad Request**           | badly formed request            |  
 | **500 Internal Server Error** | a server error occurred         |
 
 ### Delete a bucket

--- a/README.md
+++ b/README.md
@@ -110,7 +110,14 @@ POST `/v1/s3/{account}/buckets
 
 ```json
 {
-    "Bucket": "foobarbucketname"
+    "Tags": {
+        "Application": "HowToGet",
+        "COA": "Take.My.Money.$$$$",
+        "CreatedBy": "Big Bird"
+    },
+    "BucketInput": {
+        "Bucket": "foobarbucketname"
+    }
 }
 ```
 

--- a/s3api/handlers.go
+++ b/s3api/handlers.go
@@ -23,12 +23,6 @@ func (s *server) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
-
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte{})
-		return
-	}
 	w.WriteHeader(http.StatusOK)
 
 	data, err := json.Marshal(struct {

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -345,6 +345,8 @@ func (s *server) BucketShowHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
+// BucketUpdateHandler handles updating making changes to a bucket.  Currently supports:
+// - Updating the bucket's tags
 func (s *server) BucketUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)

--- a/s3api/middleware_test.go
+++ b/s3api/middleware_test.go
@@ -39,8 +39,14 @@ func TestTokenMiddleware(t *testing.T) {
 		}
 	}
 
+	// Test a bad URI
+	resp, err := http.Get(fmt.Sprintf("%s/\n", server.URL))
+	if err == nil {
+		t.Fatal("expected error for bad URL")
+	}
+
 	// Test a private URL without an auth token
-	resp, err := http.Get(fmt.Sprintf("%s/private", server.URL))
+	resp, err = http.Get(fmt.Sprintf("%s/private", server.URL))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +54,7 @@ func TestTokenMiddleware(t *testing.T) {
 		t.Errorf("Received status: %d for '%s/private', expected %d", resp.StatusCode, server.URL, http.StatusForbidden)
 	}
 
-	// Test a priate URL _with_ an auth-token
+	// Test a private URL _with_ an auth-token
 	client := &http.Client{}
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/private", server.URL), nil)
 	req.Header.Add("X-Auth-Token", psk)

--- a/s3api/routes.go
+++ b/s3api/routes.go
@@ -16,8 +16,10 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/buckets", s.BucketListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/buckets", s.BucketCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
-	// api.HandleFunc("/{account}/buckets/{bucket}", s.BucketShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
+
 	// api.HandleFunc("/{account}/buckets/{bucket}/objects", s.ObjectCountHandler).Methods(http.MethodHead)
 	api.HandleFunc("/{account}/buckets/{bucket}/users", s.UserListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/buckets/{bucket}/users", s.UserCreateHandler).Methods(http.MethodPost)

--- a/s3api/routes.go
+++ b/s3api/routes.go
@@ -8,9 +8,9 @@ import (
 
 func (s *server) routes() {
 	api := s.router.PathPrefix("/v1/s3").Subrouter()
-	api.HandleFunc("/ping", s.PingHandler)
-	api.HandleFunc("/version", s.VersionHandler)
-	api.Handle("/metrics", promhttp.Handler())
+	api.HandleFunc("/ping", s.PingHandler).Methods(http.MethodGet)
+	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
+	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
 	// Buckets handlers
 	api.HandleFunc("/{account}/buckets", s.BucketListHandler).Methods(http.MethodGet)

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta3
+apiVersion: skaffold/v1beta6
 kind: Config
 build:
   local: {}


### PR DESCRIPTION
- Add support for tagging when creating a bucket
- Add support for GET'ing a bucket, which currently just returns the tags (but can return other stuff)
- Add support for PUT'ing a bucket, which currently just updates the tags (but can update other stuff)


*Note:* this changes the POST body for creating a bucket
