### PR TITLE
Basic support for website creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ POST `/v1/s3/{account}/buckets
 {
     "Tags": [
         { "Key": "Application", "Value": "HowToGet" },
-        { "Key": "COA" "Value", "Value": "Take.My.Money.$$$$" },
+        { "Key": "COA", "Value": "Take.My.Money.$$$$" },
         { "Key": "CreatedBy", "Value": "Big Bird" }
     ],
     "BucketInput": {
@@ -194,7 +194,7 @@ PUT `/v1/s3/{account}/buckets/foobarbucketname`
 {
     "Tags": [
         { "Key": "Application", "Value": "HowToGet" },
-        { "Key": "COA" "Value", "Value": "Take.My.Money.$$$$" },
+        { "Key": "COA", "Value": "Take.My.Money.$$$$" },
         { "Key": "CreatedBy", "Value": "Big Bird" }
     ]
 }
@@ -364,7 +364,7 @@ DELETE `/v1/s3/{account}/buckets/{bucket}/users/{user}
 
 ### Create a website
 
-POST `/v1/s3/{account}/websites
+POST `/v1/s3/{account}/websites`
 
 #### Request
 
@@ -450,13 +450,13 @@ DELETE `/v1/s3/{account}/websites/{website}`
 
 ### Create a website user
 
-POST `/v1/s3/{account}/websites/{website}/users
+POST `/v1/s3/{account}/websites/{website}/users`
 
 *See [Create a bucket user](#create-a-bucket-user)*
 
 ### List users for a website
 
-GET `/v1/s3/{account}/websites/{website}/users/{user}
+GET `/v1/s3/{account}/websites/{website}/users/{user}`
 
 *See [List users for a bucket](#list-users-for-a-bucket)*
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,29 @@ GET /v1/s3/metrics
 # Managing buckets
 POST /v1/s3/{account}/buckets
 GET /v1/s3/{account}/buckets
+HEAD /v1/s3/{account}/buckets/{bucket}
 GET /v1/s3/{account}/buckets/{bucket}
+PUT /v1/s3/{account}/buckets/{bucket}
+DELETE /v1/s3/{account}/buckets/{bucket}
+
+# Managing bucket users
+POST /v1/s3/{account}/buckets/{bucket}/users
+GET /v1/s3/{account}/buckets/{bucket}/users
+PUT /v1/s3/{account}/buckets/{bucket}/users/{user}
+DELETE /v1/s3/{account}/buckets/{bucket}/users/{user}
+
+# Managing websites
+POST /v1/s3/{account}/websites
+HEAD /v1/s3/{account}/websites/{website}
+GET /v1/s3/{account}/websites/{website}
+PUT /v1/s3/{account}/websites/{website}
+DELETE /v1/s3/{account}/websites/{website}
+
+# Managing website users
+POST /v1/s3/{account}/websites/{website}/users
+GET /v1/s3/{account}/websites/{website}/users
+PUT /v1/s3/{account}/websites/{website}/users/{user}
+DELETE /v1/s3/{account}/websites/{website}/users/{user}
 ```
 
 ## Access to buckets
@@ -110,11 +132,11 @@ POST `/v1/s3/{account}/buckets
 
 ```json
 {
-    "Tags": {
-        "Application": "HowToGet",
-        "COA": "Take.My.Money.$$$$",
-        "CreatedBy": "Big Bird"
-    },
+    "Tags": [
+        { "Key": "Application", "Value": "HowToGet" },
+        { "Key": "COA" "Value", "Value": "Take.My.Money.$$$$" },
+        { "Key": "CreatedBy", "Value": "Big Bird" }
+    ],
     "BucketInput": {
         "Bucket": "foobarbucketname"
     }
@@ -164,17 +186,17 @@ POST `/v1/s3/{account}/buckets
 
 Updating a bucket currently only supports updating the bucket's tags
 
-POST `/v1/s3/{account}/buckets/foobarbucketname`
+PUT `/v1/s3/{account}/buckets/foobarbucketname`
 
 #### Request
 
 ```json
 {
-    "Tags": {
-        "Application": "HowToGet",
-        "COA": "Take.My.Money.$$$$",
-        "CreatedBy": "Big Bird"
-    }
+    "Tags": [
+        { "Key": "Application", "Value": "HowToGet" },
+        { "Key": "COA" "Value", "Value": "Take.My.Money.$$$$" },
+        { "Key": "CreatedBy", "Value": "Big Bird" }
+    ]
 }
 ```
 
@@ -268,7 +290,7 @@ POST `/v1/s3/{account}/buckets/{bucket}/users
 
 ### Reset access keys for a bucket user
 
-PUT `/v1/s3/{account}/buckets/{bucket}/users/{user}
+PUT `/v1/s3/{account}/buckets/{bucket}/users/{user}`
 
 #### Response
 
@@ -327,7 +349,6 @@ GET `/v1/s3/{account}/buckets/{bucket}/users/{user}
 ]
 ```
 
-
 ### Delete a bucket user
 
 DELETE `/v1/s3/{account}/buckets/{bucket}/users/{user}
@@ -340,6 +361,117 @@ DELETE `/v1/s3/{account}/buckets/{bucket}/users/{user}
 | **404 Not Found**             | account or user not found                |  
 | **429 Too Many Requests**     | service or rate limit exceeded           |  
 | **500 Internal Server Error** | a server error occurred                  |
+
+### Create a website
+
+POST `/v1/s3/{account}/websites
+
+#### Request
+
+```json
+{
+    "Tags": [
+        { "Key": "Application", "Value": "HowToGet" },
+        { "Key": "COA" "Value", "Value": "Take.My.Money.$$$$" },
+        { "Key": "CreatedBy", "Value": "Big Bird" }
+    ],
+    "BucketInput": {
+        "Bucket": "foobar.bulldogs.cloud"
+    }
+}
+```
+
+#### Response
+
+```json
+{
+    "Bucket": "/foobar.bulldogs.cloud",
+    "Policy": {
+        "Arn": "arn:aws:iam::846761448161:policy/foobar.bulldogs.cloud-BktAdmPlc",
+        "AttachmentCount": 0,
+        "CreateDate": "2019-03-01T15:33:52Z",
+        "DefaultVersionId": "v1",
+        "Description": null,
+        "IsAttachable": true,
+        "Path": "/",
+        "PermissionsBoundaryUsageCount": 0,
+        "PolicyId": "ABCDEFGHI12345678",
+        "PolicyName": "foobar.bulldogs.cloud-BktAdmPlc",
+        "UpdateDate": "2019-03-01T15:33:52Z"
+    },
+    "Group": {
+        "Arn": "arn:aws:iam::846761448161:group/foobar.bulldogs.cloud-BktAdmGrp",
+        "CreateDate": "2019-03-01T15:33:52Z",
+        "GroupId": "GROUPID123",
+        "GroupName": "foobar.bulldogs.cloud-BktAdmGrp",
+        "Path": "/"
+    }
+}
+```
+
+| Response Code                 | Definition                           |  
+| ----------------------------- | -------------------------------------|  
+| **202 Accepted**              | creation request accepted            |  
+| **400 Bad Request**           | badly formed request                 |  
+| **403 Forbidden**             | you don't have access to bucket      |  
+| **404 Not Found**             | account not found                    |  
+| **409 Conflict**              | bucket or iam policy  already exists |
+| **429 Too Many Requests**     | service or rate limit exceeded       |
+| **500 Internal Server Error** | a server error occurred              |
+| **503 Service Unavailable**   | an AWS service is unavailable        |
+
+### Check if a website exists
+
+HEAD `/v1/s3/{account}/websites/{website}`
+
+*See [Check if a bucket exists](#check-if-a-bucket-exists)*
+
+### Get information for a website
+
+Getting details about a website currently only returns tagging information
+
+GET `/v1/s3/{account}/websites/{website}`
+
+*See [Get information for a bucket](#get-information-for-a-bucket)*
+
+### Update a website
+
+Updating a website currently only supports updating the bucket's tags
+
+PUT `/v1/s3/{account}/websites/{website}`
+
+*See [Update a bucket](#update-a-bucket)*
+
+### Delete a website
+
+DELETE `/v1/s3/{account}/websites/{website}`
+
+*See [Delete a bucket](#delete-a-bucket)*
+
+### Create a website user
+
+POST `/v1/s3/{account}/websites/{website}/users
+
+*See [Create a bucket user](#create-a-bucket-user)*
+
+### List users for a website
+
+GET `/v1/s3/{account}/websites/{website}/users/{user}
+
+*See [List users for a bucket](#list-users-for-a-bucket)*
+
+### Reset access keys for a website user
+
+PUT `/v1/s3/{account}/websites/{website}/users/{user}`
+
+*See [Reset access keys for a bucket user](#reset-access-keys-for-a-bucket-user)*
+
+### Delete a website user
+
+DELETE `/v1/s3/{account}/websites/{website}/users/{user}`
+
+*See [Delete a bucket user](#delete-a-bucket-user)*
+
 
 ## Author
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,13 +16,14 @@ RUN go mod download
 COPY . .
 RUN go test ./... -cover
 RUN go build -o /go/api -ldflags="-X main.Version=$version -X main.VersionPrerelease=$prerelease -X main.githash=$githash -X main.buildstamp=$buildstamp" *.go
+RUN ./api -version
 
 # final stage
 FROM alpine
 MAINTAINER Camden Fisher <camden.fisher@yale.edu>
 
 WORKDIR /app
-COPY --from=build-env /go/api /app/api
+COPY --from=build-env /app/api /app/api
 RUN chmod 555 /app/api
 
 RUN apk add --no-cache bash ca-certificates wget python gettext && \

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -15,9 +15,10 @@ import (
 
 // PolicyStatement is an individual IAM Policy statement
 type PolicyStatement struct {
-	Effect   string
-	Action   []string
-	Resource []string
+	Effect    string
+	Principal string `json:",omitempty"`
+	Action    []string
+	Resource  []string
 }
 
 // PolicyDoc collects the policy statements
@@ -52,7 +53,7 @@ func NewSession(account common.Account) IAM {
 // DefaultBucketAdminPolicy generates the default policy statement for s3 buckets
 func (i *IAM) DefaultBucketAdminPolicy(bucket *string) ([]byte, error) {
 	b := aws.StringValue(bucket)
-	log.Debugf("generating default bucket admin policy for bucket: %s", b)
+	log.Debugf("generating default bucket admin policy for %s", b)
 	policyDoc, err := json.Marshal(PolicyDoc{
 		Version: "2012-10-17",
 		Statement: []PolicyStatement{
@@ -70,7 +71,42 @@ func (i *IAM) DefaultBucketAdminPolicy(bucket *string) ([]byte, error) {
 	})
 
 	if err != nil {
-		log.Errorf("failed to generate default bucket admin policy for bucket: %s: %s", b, err)
+		log.Errorf("failed to generate default bucket admin policy for %s: %s", b, err)
+		return []byte{}, err
+	}
+	log.Debugf("creating policy with document %s", string(policyDoc))
+
+	return policyDoc, nil
+}
+
+// DefaultWebsiteAccessPolicy generated the default website access policy statement for s3 websites
+//   {
+//     "Version":"2012-10-17",
+//     "Statement":[{
+// 	     "Sid":"PublicReadGetObject",
+// 		 "Effect":"Allow",
+// 	     "Principal": "*",
+// 	     "Action":["s3:GetObject"],
+// 	     "Resource":["arn:aws:s3:::example-bucket/*"]
+//     }]
+//   }
+func (i *IAM) DefaultWebsiteAccessPolicy(bucket *string) ([]byte, error) {
+	b := aws.StringValue(bucket)
+	log.Debugf("generating default bucket website policy for %s", b)
+	policyDoc, err := json.Marshal(PolicyDoc{
+		Version: "2012-10-17",
+		Statement: []PolicyStatement{
+			PolicyStatement{
+				Effect:    "Allow",
+				Principal: "*",
+				Action:    []string{"s3:GetObject"},
+				Resource:  []string{fmt.Sprintf("arn:aws:s3:::%s/*", b)},
+			},
+		},
+	})
+
+	if err != nil {
+		log.Errorf("failed to generate default bucket website policy for %s: %s", b, err)
 		return []byte{}, err
 	}
 	log.Debugf("creating policy with document %s", string(policyDoc))

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -59,8 +59,20 @@ var defaultPolicyDoc = PolicyDoc{
 	},
 }
 
+var defaultWebsitePolicyDoc = PolicyDoc{
+	Version: "2012-10-17",
+	Statement: []PolicyStatement{
+		PolicyStatement{
+			Effect:    "Allow",
+			Principal: "*",
+			Action:    []string{"s3:GetObject"},
+			Resource:  []string{fmt.Sprintf("arn:aws:s3:::%s/*", bucket)},
+		},
+	},
+}
+
 func TestDefaultBucketAdminPolicy(t *testing.T) {
-	dpd, err := json.Marshal(defaultPolicyDoc)
+	p, err := json.Marshal(defaultPolicyDoc)
 	if err != nil {
 		t.Errorf("expected to marshall defaultPolicyDoc with nil error, got %s", err)
 	}
@@ -70,7 +82,23 @@ func TestDefaultBucketAdminPolicy(t *testing.T) {
 		t.Errorf("expected DefaultBucketAdminPolicy to return nil error, got %s", err)
 	}
 
-	if !bytes.Equal(policyBytes, dpd) {
+	if !bytes.Equal(policyBytes, p) {
 		t.Errorf("expected: %s\ngot: %s", defaultPolicyDoc, policyBytes)
+	}
+}
+
+func TestDefaultWebsiteAccessPolicy(t *testing.T) {
+	p, err := json.Marshal(defaultWebsitePolicyDoc)
+	if err != nil {
+		t.Errorf("expected to marshall defaultWebsitePolicyDoc with nil error, got %s", err)
+	}
+
+	policyBytes, err := i.DefaultWebsiteAccessPolicy(&bucket)
+	if err != nil {
+		t.Errorf("expected DefaultWebsiteAccessPolicy to return nil error, got %s", err)
+	}
+
+	if !bytes.Equal(policyBytes, p) {
+		t.Errorf("expected: %s\ngot: %s", defaultWebsitePolicyDoc, policyBytes)
 	}
 }

--- a/k8s/k8s-api.yaml
+++ b/k8s/k8s-api.yaml
@@ -10,7 +10,7 @@ spec:
       - path: /v1/s3
         backend:
           serviceName: s3api
-          servicePort: 80
+          servicePort: http-s3api
 ---
 apiVersion: v1
 kind: Service
@@ -24,7 +24,8 @@ spec:
     app: s3api
     tier: api
   ports:
-    - protocol: TCP
+    - name: http-s3api
+      protocol: TCP
       port: 80
       targetPort: 8080
 ---

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -189,7 +189,7 @@ func (s *S3) UpdateWebsiteConfig(ctx context.Context, input *s3.PutBucketWebsite
 
 		return apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
 	}
-	return err
+	return nil
 }
 
 // UpdateBucketPolicy sets a bucket access policy
@@ -211,5 +211,5 @@ func (s *S3) UpdateBucketPolicy(ctx context.Context, input *s3.PutBucketPolicyIn
 
 		return apierror.New(apierror.ErrInternalError, "unknown error occurred", err)
 	}
-	return err
+	return nil
 }

--- a/s3/buckets_test.go
+++ b/s3/buckets_test.go
@@ -31,11 +31,6 @@ var testBucket3 = s3.Bucket{
 
 var testBuckets1 = []*s3.Bucket{&testBucket1, &testBucket2, &testBucket3}
 
-var testTagsMap = map[string]string{
-	"foo": "bar",
-	"fuz": "buz",
-	"fiz": "biz",
-}
 var testTags1 = []*s3.Tag{
 	&s3.Tag{Key: aws.String("foo"), Value: aws.String("bar")},
 	&s3.Tag{Key: aws.String("fuz"), Value: aws.String("buz")},
@@ -91,6 +86,27 @@ func (m *mockS3Client) PutBucketTaggingWithContext(ctx context.Context, input *s
 		return nil, m.err
 	}
 	return &s3.PutBucketTaggingOutput{}, nil
+}
+
+func (m *mockS3Client) PutBucketWebsiteWithContext(ctx context.Context, input *s3.PutBucketWebsiteInput, opts ...request.Option) (*s3.PutBucketWebsiteOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	// check that IndexDocument is set
+	if input.WebsiteConfiguration.IndexDocument == nil {
+		return nil, errors.New("expected index.html to be set for IndexDocument")
+	}
+
+	return &s3.PutBucketWebsiteOutput{}, nil
+}
+
+func (m *mockS3Client) PutBucketPolicyWithContext(ctx context.Context, input *s3.PutBucketPolicyInput, opts ...request.Option) (*s3.PutBucketPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &s3.PutBucketPolicyOutput{}, nil
 }
 
 func TestBucketExists(t *testing.T) {
@@ -336,7 +352,7 @@ func TestGetBucketTags(t *testing.T) {
 	s := S3{Service: newMockS3Client(t, nil)}
 
 	// test success
-	expected := testTagsMap
+	expected := testTags1
 	out, err := s.GetBucketTags(context.TODO(), "testBucket1")
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
@@ -344,6 +360,16 @@ func TestGetBucketTags(t *testing.T) {
 
 	if !reflect.DeepEqual(out, expected) {
 		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	// test empty bucket
+	out, err = s.GetBucketTags(context.TODO(), "")
+	if err == nil {
+		t.Error("expected api error for empty bucket, got nil")
+	}
+
+	if len(out) != 0 {
+		t.Errorf("expected empty tags list for empty bucket, got %d entries", len(out))
 	}
 
 	// test some unexpected AWS error
@@ -373,20 +399,20 @@ func TestTagBucket(t *testing.T) {
 	s := S3{Service: newMockS3Client(t, nil)}
 
 	// test success
-	err := s.TagBucket(context.TODO(), "testBucket1", testTagsMap)
+	err := s.TagBucket(context.TODO(), "testBucket1", testTags1)
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
 	// test empty tags
-	err = s.TagBucket(context.TODO(), "testBucket1", map[string]string{})
+	err = s.TagBucket(context.TODO(), "testBucket1", []*s3.Tag{})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
 	// test some unexpected AWS error
 	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchUpload, "no such upload", nil)
-	err = s.TagBucket(context.TODO(), "testBucket1", testTagsMap)
+	err = s.TagBucket(context.TODO(), "testBucket1", testTags1)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -397,7 +423,129 @@ func TestTagBucket(t *testing.T) {
 
 	// test non-aws error
 	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
-	err = s.TagBucket(context.TODO(), "testBucket1", testTagsMap)
+	err = s.TagBucket(context.TODO(), "testBucket1", testTags1)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
+func TestUpdateWebsiteConfig(t *testing.T) {
+	s := S3{Service: newMockS3Client(t, nil)}
+
+	// test success
+	err := s.UpdateWebsiteConfig(context.TODO(), &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String("testbucket"),
+		WebsiteConfiguration: &s3.WebsiteConfiguration{},
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	// test nil input
+	err = s.UpdateWebsiteConfig(context.TODO(), nil)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test empty bucket name and website configuration
+	err = s.UpdateWebsiteConfig(context.TODO(), &s3.PutBucketWebsiteInput{})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test some other, unexpected AWS error
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchKey, "no such key", nil)
+	err = s.UpdateWebsiteConfig(context.TODO(), &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String("testbucket"),
+		WebsiteConfiguration: &s3.WebsiteConfiguration{},
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
+	err = s.UpdateWebsiteConfig(context.TODO(), &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String("testbucket"),
+		WebsiteConfiguration: &s3.WebsiteConfiguration{},
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
+func TestUpdateBucketPolicy(t *testing.T) {
+	s := S3{Service: newMockS3Client(t, nil)}
+
+	// test success
+	err := s.UpdateBucketPolicy(context.TODO(), &s3.PutBucketPolicyInput{
+		Bucket: aws.String("testbucket"),
+		Policy: aws.String("somepolicy"),
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	// test nil input
+	err = s.UpdateBucketPolicy(context.TODO(), nil)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test empty bucket name and policy
+	err = s.UpdateBucketPolicy(context.TODO(), &s3.PutBucketPolicyInput{})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test some other, unexpected AWS error
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchKey, "no such key", nil)
+	err = s.UpdateBucketPolicy(context.TODO(), &s3.PutBucketPolicyInput{
+		Bucket: aws.String("testbucket"),
+		Policy: aws.String("somepolicy"),
+	})
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
+	err = s.UpdateBucketPolicy(context.TODO(), &s3.PutBucketPolicyInput{
+		Bucket: aws.String("testbucket"),
+		Policy: aws.String("somepolicy"),
+	})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -42,7 +42,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Tags        map[string]string
+		Tags        []*s3.Tag
 		BucketInput s3.CreateBucketInput
 	}
 	err := json.NewDecoder(r.Body).Decode(&req)
@@ -328,7 +328,7 @@ func (s *server) BucketShowHandler(w http.ResponseWriter, r *http.Request) {
 
 	// setup output struct
 	var output = struct {
-		Tags map[string]string
+		Tags []*s3.Tag
 	}{}
 
 	output.Tags = tags
@@ -360,7 +360,7 @@ func (s *server) BucketUpdateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Tags map[string]string
+		Tags []*s3.Tag
 	}
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -129,7 +129,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		panic(msg)
 	}
 
-	// append policy delete to rollback tasks
+	// append group delete to rollback tasks
 	rbfunc = func() error {
 		return func() error {
 			if _, err := iamService.DeleteGroup(r.Context(), &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {

--- a/s3api/handlers_website.go
+++ b/s3api/handlers_website.go
@@ -1,0 +1,212 @@
+package s3api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/YaleSpinup/s3-api/apierror"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// CreateWebsiteHandler orchestrates the creation of a new s3 bucket website with rollback in
+// the event of failure.  The operations are:
+// 1. create the bucket with the given name
+// 2. tag the bucket with given tags
+// 3. apply the website configuration to the bucket
+// 4. generate the default admin bucket policy
+// 5. create the admin bucket policy
+// 6. create the bucket admin group, '<bucketName>-BktAdmGrp'
+// 7. attach the bucket admin policy to the bucket admin group
+// Note: this does _not_ create any users for managing the bucket
+func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
+	w = LogWriter{w}
+	vars := mux.Vars(r)
+	account := vars["account"]
+	s3Service, ok := s.s3Services[account]
+	if !ok {
+		msg := fmt.Sprintf("s3 service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	iamService, ok := s.iamServices[account]
+	if !ok {
+		msg := fmt.Sprintf("IAM service not found for account: %s", account)
+		handleError(w, apierror.New(apierror.ErrNotFound, msg, nil))
+		return
+	}
+
+	var req struct {
+		Tags                 []*s3.Tag
+		BucketInput          s3.CreateBucketInput
+		WebsiteConfiguration s3.WebsiteConfiguration
+	}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		msg := fmt.Sprintf("cannot decode body into create website input: %s", err)
+		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
+		return
+	}
+
+	// setup err var, rollback function list and defer execution
+	var rollBackTasks []func() error
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	bucketName := aws.StringValue(req.BucketInput.Bucket)
+	bucketOutput, err := s3Service.CreateBucket(r.Context(), &req.BucketInput)
+	if err != nil {
+		msg := fmt.Sprintf("failed to create bucket %s", bucketName)
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	// append bucket delete to rollback tasks
+	rbfunc := func() error {
+		return func() error {
+			if _, err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucketName)}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	err = s3Service.TagBucket(r.Context(), bucketName, req.Tags)
+	if err != nil {
+		msg := fmt.Sprintf("failed to tag bucket %s: %s", bucketName, err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	err = s3Service.UpdateWebsiteConfig(r.Context(), &s3.PutBucketWebsiteInput{
+		Bucket:               aws.String(bucketName),
+		WebsiteConfiguration: &req.WebsiteConfiguration,
+	})
+	if err != nil {
+		msg := fmt.Sprintf("failed to configure bucket %s as website: %s", bucketName, err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	defaultWebsitePolicy, err := iamService.DefaultWebsiteAccessPolicy(aws.String(bucketName))
+	if err != nil {
+		msg := fmt.Sprintf("failed building default website bucket access policy for %s: %s", bucketName, err.Error())
+		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
+		return
+	}
+
+	err = s3Service.UpdateBucketPolicy(r.Context(), &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucketName),
+		Policy: aws.String(string(defaultWebsitePolicy)),
+	})
+
+	// build the default IAM bucket admin policy (from the config and known inputs)
+	defaultPolicy, err := iamService.DefaultBucketAdminPolicy(aws.String(bucketName))
+	if err != nil {
+		msg := fmt.Sprintf("failed building default IAM policy for bucket %s: %s", bucketName, err.Error())
+		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
+		return
+	}
+
+	policyOutput, err := iamService.CreatePolicy(r.Context(), &iam.CreatePolicyInput{
+		Description:    aws.String(fmt.Sprintf("Admin policy for %s bucket", bucketName)),
+		PolicyDocument: aws.String(string(defaultPolicy)),
+		PolicyName:     aws.String(fmt.Sprintf("%s-BktAdmPlc", bucketName)),
+	})
+
+	if err != nil {
+		msg := fmt.Sprintf("failed to create policy: %s", err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	// append policy delete to rollback tasks
+	rbfunc = func() error {
+		return func() error {
+			if _, err := iamService.DeletePolicy(r.Context(), &iam.DeletePolicyInput{PolicyArn: policyOutput.Policy.Arn}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	groupName := fmt.Sprintf("%s-BktAdmGrp", bucketName)
+	group, err := iamService.CreateGroup(r.Context(), &iam.CreateGroupInput{
+		GroupName: aws.String(groupName),
+	})
+
+	if err != nil {
+		msg := fmt.Sprintf("failed to create group: %s", err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	// append policy delete to rollback tasks
+	rbfunc = func() error {
+		return func() error {
+			if _, err := iamService.DeleteGroup(r.Context(), &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {
+				return err
+			}
+			return nil
+		}()
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	if _, err = iamService.AttachGroupPolicy(r.Context(), &iam.AttachGroupPolicyInput{
+		GroupName: aws.String(groupName),
+		PolicyArn: policyOutput.Policy.Arn,
+	}); err != nil {
+		msg := fmt.Sprintf("failed to create group: %s", err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	output := struct {
+		Bucket *string
+		Policy *iam.Policy
+		Group  *iam.Group
+	}{
+		bucketOutput.Location,
+		policyOutput.Policy,
+		group.Group,
+	}
+
+	j, err := json.Marshal(output)
+	if err != nil {
+		log.Errorf("cannot marshal reasponse(%v) into JSON: %s", output, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(j)
+}
+
+// rollBack executes functions from a stack of rollback functions
+func rollBack(t *[]func() error) {
+	if t == nil {
+		return
+	}
+
+	tasks := *t
+	log.Errorf("executing rollback of %d tasks", len(tasks))
+	for i := len(tasks) - 1; i >= 0; i-- {
+		f := tasks[i]
+		if funcerr := f(); funcerr != nil {
+			log.Errorf("rollback task error: %s, continuing rollback", funcerr)
+		}
+	}
+}

--- a/s3api/handlers_website.go
+++ b/s3api/handlers_website.go
@@ -153,7 +153,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// append policy delete to rollback tasks
+	// append group delete to rollback tasks
 	rbfunc = func() error {
 		return func() error {
 			if _, err := iamService.DeleteGroup(r.Context(), &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {
@@ -168,7 +168,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		GroupName: aws.String(groupName),
 		PolicyArn: policyOutput.Policy.Arn,
 	}); err != nil {
-		msg := fmt.Sprintf("failed to create group: %s", err.Error())
+		msg := fmt.Sprintf("failed to attach policy %s to group %s: %s", aws.StringValue(policyOutput.Policy.Arn), groupName, err.Error())
 		handleError(w, errors.Wrap(err, msg))
 		return
 	}

--- a/s3api/routes.go
+++ b/s3api/routes.go
@@ -12,7 +12,7 @@ func (s *server) routes() {
 	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
-	// Buckets handlers
+	// buckets handlers
 	api.HandleFunc("/{account}/buckets", s.BucketListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/buckets", s.BucketCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
@@ -20,9 +20,22 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/buckets/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
 
-	// api.HandleFunc("/{account}/buckets/{bucket}/objects", s.ObjectCountHandler).Methods(http.MethodHead)
+	// bucket users handlers
 	api.HandleFunc("/{account}/buckets/{bucket}/users", s.UserListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/buckets/{bucket}/users", s.UserCreateHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/buckets/{bucket}/users/{user}", s.UserDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/buckets/{bucket}/users/{user}", s.UserUpdateKeyHandler).Methods(http.MethodPut)
+
+	// websites handlers
+	api.HandleFunc("/{account}/websites", s.CreateWebsiteHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/websites/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
+	api.HandleFunc("/{account}/websites/{bucket}", s.BucketShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/websites/{bucket}", s.BucketDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/websites/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
+
+	// website users handlers
+	api.HandleFunc("/{account}/websites/{bucket}/users", s.UserListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/websites/{bucket}/users", s.UserCreateHandler).Methods(http.MethodPost)
+	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.UserDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.UserUpdateKeyHandler).Methods(http.MethodPut)
 }


### PR DESCRIPTION
Supports:
* creating the bucket
* setting the website configuration
* configuring the bucket policy for public access

Does not yet support:
* creating a dns record for the site
* assigning the SSL certificate
* setting up the cloudfront distribution

Additionally:
* Update readme with all endpoints
* Change Tags to be the native AWS format instead of one that makes sense 😆 
* change the service ports for k8s to be istio compliant
* introduce a better way to rollback without panicing which will be applied to bucket creation as well