### PR TITLE
Add support for logging bucket access to a bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ PUT /v1/s3/{account}/websites/{website}/users/{user}
 DELETE /v1/s3/{account}/websites/{website}/users/{user}
 ```
 
+## Authentication
+
+Authentication is accomplished via a pre-shared key.  This is done via the `X-Auth-Token` header.
+
 ## Access to buckets
 
 When creating a bucket, by default, an IAM policy (of the same name) is created with full access to that

--- a/common/config.go
+++ b/common/config.go
@@ -24,6 +24,13 @@ type Account struct {
 	Secret                 string
 	DefaultS3BucketActions []string
 	DefaultS3ObjectActions []string
+	AccessLog              AccessLog
+}
+
+// AccessLog is the configuration for a bucket's access log
+type AccessLog struct {
+	Bucket string
+	Prefix string
 }
 
 type Version struct {

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -20,7 +20,11 @@ var testConfig = []byte(
 			],
 			"defaultS3ObjectActions": [
 				"s3:*"
-			]
+			],
+			"accessLog": {
+				"bucket": "foobucket",
+				"prefix": "spinup"
+			}
 		  },
 		  "provider2": {
 			"region": "us-west-1",
@@ -48,6 +52,10 @@ func TestReadConfig(t *testing.T) {
 				},
 				DefaultS3ObjectActions: []string{
 					"s3:*",
+				},
+				AccessLog: AccessLog{
+					Bucket: "foobucket",
+					Prefix: "spinup",
 				},
 			},
 			"provider2": Account{

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -57,6 +57,63 @@
         "bucket": "{{ .spinup_logging_bucket }}",
         "prefix": "s3"
       }
+    },
+    "spinupsec": {
+      "region": "us-east-1",
+      "akid": "{{ .spinupsec_akid }}",
+      "secret": "{{ .spinupsec_secret }}",
+      "defaultS3BucketActions": [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteBucketWebsite",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetAccelerateConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "s3:GetBucketNotification",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketTagging",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketWebsite",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:GetReplicationConfiguration",
+        "s3:ListAllMyBuckets",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions",
+        "s3:ListMultipartUploadParts",
+        "s3:PutAccelerateConfiguration",
+        "s3:PutBucketAcl",
+        "s3:PutBucketCORS",
+        "s3:PutBucketLogging",
+        "s3:PutBucketNotification",
+        "s3:PutBucketPolicy",
+        "s3:PutBucketRequestPayment",
+        "s3:PutBucketTagging",
+        "s3:PutBucketVersioning",
+        "s3:PutBucketWebsite",
+        "s3:PutLifecycleConfiguration",
+        "s3:PutReplicationConfiguration",
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:PutObjectVersionAcl",
+        "s3:ReplicateDelete",
+        "s3:ReplicateObject",
+        "s3:RestoreObject"
+      ],
+      "defaultS3ObjectActions": [
+        "s3:*"
+      ],
+      "accessLog": {
+        "bucket": "{{ .spinupsec_logging_bucket }}",
+        "prefix": "s3"
+      }
     }
   },
   "token": "{{ .api_token }}",

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -52,7 +52,11 @@
       ],
       "defaultS3ObjectActions": [
         "s3:*"
-      ]
+      ],
+      "accessLog": {
+        "bucket": "{{ .spinup_logging_bucket }}",
+        "prefix": "s3"
+      }
     }
   },
   "token": "{{ .api_token }}",

--- a/iam/user_test.go
+++ b/iam/user_test.go
@@ -861,18 +861,13 @@ func TestRemoveUserFromGroup(t *testing.T) {
 	i := IAM{Service: newMockIAMClient(t, nil)}
 
 	// test success
-	expected := &iam.RemoveUserFromGroupOutput{}
-	out, err := i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err := i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
-	if !reflect.DeepEqual(out, expected) {
-		t.Errorf("expected %+v, got %+v", expected, out)
-	}
-
 	// test nil input
-	_, err = i.RemoveUserFromGroup(context.TODO(), nil)
+	err = i.RemoveUserFromGroup(context.TODO(), nil)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -882,7 +877,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 	}
 
 	// test empty user name and group name
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -893,7 +888,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 
 	// test ErrCodeNoSuchEntityException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeNoSuchEntityException, "not found", nil)
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrNotFound {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
@@ -904,7 +899,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 
 	// test ErrCodeLimitExceededException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeLimitExceededException, "limit exceeded", nil)
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrLimitExceeded {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrLimitExceeded, aerr.Code)
@@ -915,7 +910,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 
 	// test ErrCodeServiceFailureException
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeServiceFailureException, "service failure", nil)
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrServiceUnavailable {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
@@ -926,7 +921,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 
 	// test some other, unexpected AWS error
 	i.Service.(*mockIAMClient).err = awserr.New(iam.ErrCodeDeleteConflictException, "delete conflict", nil)
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -937,7 +932,7 @@ func TestRemoveUserFromGroup(t *testing.T) {
 
 	// test non-aws error
 	i.Service.(*mockIAMClient).err = errors.New("things blowing up!")
-	_, err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
+	err = i.RemoveUserFromGroup(context.TODO(), &iam.RemoveUserFromGroupInput{UserName: aws.String("testuser"), GroupName: aws.String("testgroup")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -12,7 +12,9 @@ import (
 
 // S3 is a wrapper around the aws S3 service with some default config info
 type S3 struct {
-	Service s3iface.S3API
+	Service             s3iface.S3API
+	LoggingBucket       string
+	LoggingBucketPrefix string
 }
 
 // NewSession creates a new S3 session
@@ -24,6 +26,8 @@ func NewSession(account common.Account) S3 {
 		Region:      aws.String(account.Region),
 	}))
 	s.Service = s3.New(sess)
+	s.LoggingBucket = account.AccessLog.Bucket
+	s.LoggingBucketPrefix = account.AccessLog.Prefix
 	return s
 }
 

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -107,12 +107,14 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// enable logging access for the bucket to a central repo
-	err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
-	if err != nil {
-		msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
+	// enable logging access for the bucket to a central repo if the target bucket is set
+	if s3Service.LoggingBucket != "" {
+		err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
+		if err != nil {
+			msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
+			handleError(w, errors.Wrap(err, msg))
+			return
+		}
 	}
 
 	// build the default IAM bucket admin policy (from the config and known inputs)

--- a/s3api/handlers_buckets.go
+++ b/s3api/handlers_buckets.go
@@ -107,6 +107,14 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// enable logging access for the bucket to a central repo
+	err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
+	if err != nil {
+		msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
 	// build the default IAM bucket admin policy (from the config and known inputs)
 	defaultPolicy, err := iamService.DefaultBucketAdminPolicy(aws.String(bucketName))
 	if err != nil {
@@ -317,6 +325,22 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			break
+		}
+	}
+
+	users, err := iamService.ListGroupUsers(r.Context(), &iam.GetGroupInput{GroupName: aws.String(groupName)})
+	if err != nil {
+		log.Warnf("failed to list group's users when deleting bucket %s: %s", bucket, err)
+		j, _ := json.Marshal("failed to list group users: " + err.Error())
+		w.Write(j)
+	}
+
+	for _, u := range users {
+		if err := iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{UserName: u.UserName, GroupName: aws.String(groupName)}); err != nil {
+			log.Warnf("failed to remove user %s from group %s when deleting bucket %s: %s", aws.StringValue(u.UserName), groupName, bucket, err)
+			j, _ := json.Marshal("failed to remove user from group group: " + err.Error())
+			w.Write(j)
+			return
 		}
 	}
 

--- a/s3api/handlers_users.go
+++ b/s3api/handlers_users.go
@@ -154,7 +154,7 @@ func (s *server) UserDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// remove the user from all group membership
 	for _, g := range groups {
-		_, err = iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{UserName: aws.String(user), GroupName: g.GroupName})
+		err = iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{UserName: aws.String(user), GroupName: g.GroupName})
 		if err != nil {
 			handleError(w, err)
 			return

--- a/s3api/handlers_website.go
+++ b/s3api/handlers_website.go
@@ -109,11 +109,13 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// enable logging access for the website/bucket to a central repo
-	err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
-	if err != nil {
-		msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
+	if s3Service.LoggingBucket != "" {
+		err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
+		if err != nil {
+			msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
+			handleError(w, errors.Wrap(err, msg))
+			return
+		}
 	}
 
 	err = s3Service.UpdateWebsiteConfig(r.Context(), &s3.PutBucketWebsiteInput{

--- a/s3api/handlers_website.go
+++ b/s3api/handlers_website.go
@@ -89,7 +89,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// enable AWS managed serverside encryption for the bucket
+	// enable AWS managed serverside encryption for the website/bucket
 	err = s3Service.UpdateBucketEncryption(r.Context(), &s3.PutBucketEncryptionInput{
 		Bucket: aws.String(bucketName),
 		ServerSideEncryptionConfiguration: &s3.ServerSideEncryptionConfiguration{
@@ -104,6 +104,14 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		msg := fmt.Sprintf("failed to enable encryption for bucket %s: %s", bucketName, err.Error())
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
+	// enable logging access for the website/bucket to a central repo
+	err = s3Service.UpdateBucketLogging(r.Context(), bucketName, s3Service.LoggingBucket, s3Service.LoggingBucketPrefix)
+	if err != nil {
+		msg := fmt.Sprintf("failed to enable logging for bucket %s: %s", bucketName, err.Error())
 		handleError(w, errors.Wrap(err, msg))
 		return
 	}


### PR DESCRIPTION
* adds support for access logging for s3 buckets
* removes all users from a group when deleting a bucket so order doesn't matter
* cleans up the response from `RemoveUserFromGroup`

We probably will need to enable cloudtrail data plane logging as well.  We might want to just replace this access logging with that.