### PR TITLE
Delete website endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,7 +732,54 @@ PUT `/v1/s3/{account}/websites/{website}`
 
 DELETE `/v1/s3/{account}/websites/{website}`
 
-*See [Delete a bucket](#delete-a-bucket)*
+#### Response
+
+Responds with a status code and the deleted objects
+
+```json
+{
+    "Website": "foobar.bulldogs.cloud",
+    "Users": [],
+    "Policy": "foobar.bulldogs.cloud-BktAdmPlc",
+    "Group": "foobar.bulldogs.cloud-BktAdmGrp",
+    "DNSRecord": {
+        "AliasTarget": {
+            "DNSName": "abcdefgh12345.cloudfront.net.",
+            "EvaluateTargetHealth": false,
+            "HostedZoneId": "ABCDEFGHIJ12345"
+        },
+        "Name": "foobar.bulldogs.cloud.",
+        "Type": "A",
+        ...
+    },
+    "Distribution": {
+        "ARN": "arn:aws:cloudfront::12345678910:distribution/ABCDEFGHIJKL",
+        "DistributionConfig": {
+            "Aliases": {
+                "Items": [
+                    "foobar.bulldogs.cloud"
+                ],
+                "Quantity": 1
+            },
+            ...
+        },
+        "DomainName": "1234567abcdef.cloudfront.net",
+        "Id": "ABCDEFGHIJKLMNOP",
+        "Status": "InProgress"
+        ...
+    },
+}
+```
+
+| Response Code                 | Definition                      |  
+| ----------------------------- | --------------------------------|  
+| **200 OK**                    | deleted bucket                  |  
+| **400 Bad Request**           | badly formed request            |  
+| **403 Forbidden**             | you don't have access to bucket |  
+| **404 Not Found**             | account or bucket not found     |  
+| **409 Conflict**              | bucket is not empty             |
+| **500 Internal Server Error** | a server error occurred         |
+
 
 ### Create a website user
 

--- a/README.md
+++ b/README.md
@@ -773,11 +773,11 @@ Responds with a status code and the deleted objects
 
 | Response Code                 | Definition                      |  
 | ----------------------------- | --------------------------------|  
-| **200 OK**                    | deleted bucket                  |  
+| **200 OK**                    | deleted website                 |  
 | **400 Bad Request**           | badly formed request            |  
-| **403 Forbidden**             | you don't have access to bucket |  
-| **404 Not Found**             | account or bucket not found     |  
-| **409 Conflict**              | bucket is not empty             |
+| **403 Forbidden**             | you don't have access           |  
+| **404 Not Found**             | account or website not found    |  
+| **409 Conflict**              | website bucket is not empty     |
 | **500 Internal Server Error** | a server error occurred         |
 
 

--- a/api/handlers_buckets.go
+++ b/api/handlers_buckets.go
@@ -73,7 +73,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	// append bucket delete to rollback tasks
 	rbfunc := func() error {
 		return func() error {
-			if _, err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucketName)}); err != nil {
+			if err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucketName)}); err != nil {
 				return err
 			}
 			return nil
@@ -290,7 +290,7 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+	err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
 	if err != nil {
 		handleError(w, err)
 		return

--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -410,8 +410,8 @@ func (s *server) WebsiteShowHandler(w http.ResponseWriter, r *http.Request) {
 // 2. a list of policies attached to the bucket admin group (<bucketName>-BktAdmGrp) is gathered
 // 3. each of those policies is detached from the group and if it starts with '<bucketName>-', it is deleted
 // 4. the bucket admin group is deleted
-// 5. delete the route53 dns record
-// 6. disable the cloudfront distribution
+// 5. the route53 dns record is deleted
+// 6. the cloudfront distribution is disabled for async processing
 func (s *server) WebsiteDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)

--- a/api/routes.go
+++ b/api/routes.go
@@ -31,7 +31,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/websites", s.CreateWebsiteHandler).Methods(http.MethodPost)
 	api.HandleFunc("/{account}/websites/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
 	api.HandleFunc("/{account}/websites/{website}", s.WebsiteShowHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/websites/{bucket}", s.BucketDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/websites/{website}", s.WebsiteDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/websites/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
 
 	// website users handlers

--- a/route53/records_test.go
+++ b/route53/records_test.go
@@ -286,6 +286,125 @@ func TestCreateRecord(t *testing.T) {
 	}
 }
 
+func TestDeleteRecord(t *testing.T) {
+	r := Route53{
+		Service: newmockRoute53Client(t, nil),
+		Domains: map[string]common.Domain{
+			"hyper.converged": common.Domain{
+				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
+			},
+		},
+	}
+
+	// test success
+	expected := &testChangeInfo
+	out, err := r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	// test nil input
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, nil)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// * ErrCodeNoSuchHostedZone "NoSuchHostedZone"
+	// No hosted zone exists with the ID that you specified.
+	r.Service.(*mockRoute53Client).err = awserr.New(route53.ErrCodeNoSuchHostedZone, "NoSuchHostedZone", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// * ErrCodeNoSuchHealthCheck "NoSuchHealthCheck"
+	// No health check exists with the specified ID.
+	r.Service.(*mockRoute53Client).err = awserr.New(route53.ErrCodeNoSuchHealthCheck, "NoSuchHealthCheck", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// * ErrCodeInvalidChangeBatch "InvalidChangeBatch"
+	// This exception contains a list of messages that might contain one or more
+	// error messages. Each error message indicates one error in the change batch.
+	r.Service.(*mockRoute53Client).err = awserr.New(route53.ErrCodeInvalidChangeBatch, "InvalidChangeBatch", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// * ErrCodeInvalidInput "InvalidInput"
+	// The input is not valid.
+	r.Service.(*mockRoute53Client).err = awserr.New(route53.ErrCodeInvalidInput, "InvalidInput", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// * ErrCodePriorRequestNotComplete "PriorRequestNotComplete"
+	// If Amazon Route 53 can't process a request before the next request arrives,
+	// it will reject subsequent requests for the same hosted zone and return an
+	// HTTP 400 error (Bad request). If Route 53 returns this error repeatedly for
+	// the same request, we recommend that you wait, in intervals of increasing
+	// duration, before you try the request again.
+	r.Service.(*mockRoute53Client).err = awserr.New(route53.ErrCodePriorRequestNotComplete, "PriorRequestNotComplete", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrServiceUnavailable, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test some other, unexpected AWS error
+	r.Service.(*mockRoute53Client).err = awserr.New("UnknownThingyBrokeYo", "ThingyBroke", nil)
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrBadRequest {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	r.Service.(*mockRoute53Client).err = errors.New("things blowing up!")
+	_, err = r.DeleteRecord(context.TODO(), testHostedZoneID, &testResourceRecordSet)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
 func TestListRecords(t *testing.T) {
 	r := Route53{
 		Service: newmockRoute53Client(t, nil),

--- a/s3/buckets_test.go
+++ b/s3/buckets_test.go
@@ -315,18 +315,13 @@ func TestDeleteBucket(t *testing.T) {
 	s := S3{Service: newMockS3Client(t, nil)}
 
 	// test success
-	expected := &s3.DeleteBucketOutput{}
-	out, err := s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err := s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if err != nil {
 		t.Errorf("expected nil error, got: %s", err)
 	}
 
-	if !reflect.DeepEqual(out, expected) {
-		t.Errorf("expected %+v, got %+v", expected, out)
-	}
-
 	// test nil input
-	_, err = s.DeleteEmptyBucket(context.TODO(), nil)
+	err = s.DeleteEmptyBucket(context.TODO(), nil)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -336,7 +331,7 @@ func TestDeleteBucket(t *testing.T) {
 	}
 
 	// test empty bucket name
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -347,7 +342,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test ErrCodeNoSuchBucket
 	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchBucket, "bucket not found", nil)
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrNotFound {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
@@ -358,7 +353,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test NotFound
 	s.Service.(*mockS3Client).err = awserr.New("NotFound", "bucket not found", nil)
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrNotFound {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
@@ -369,7 +364,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test BucketNotEmpty
 	s.Service.(*mockS3Client).err = awserr.New("BucketNotEmpty", "bucket not empty", nil)
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrConflict {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrConflict, aerr.Code)
@@ -380,7 +375,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test Forbidden
 	s.Service.(*mockS3Client).err = awserr.New("Forbidden", "bucket not empty", nil)
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrForbidden {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrForbidden, aerr.Code)
@@ -391,7 +386,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test some other, unexpected AWS error
 	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchKey, "no such key", nil)
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrBadRequest {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrBadRequest, aerr.Code)
@@ -402,7 +397,7 @@ func TestDeleteBucket(t *testing.T) {
 
 	// test non-aws error
 	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
-	_, err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
+	err = s.DeleteEmptyBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: aws.String("testbucket")})
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)


### PR DESCRIPTION
```golang
// WebsiteDeleteHandler deletes all of the resources for a static website.  The operations are
// 1. the website bucket is deleted, this will fail if the bucket is not empty
// 2. a list of policies attached to the bucket admin group (<bucketName>-BktAdmGrp) is gathered
// 3. each of those policies is detached from the group and if it starts with '<bucketName>-', it is deleted
// 4. the bucket admin group is deleted
// 5. the route53 dns record is deleted
// 6. the cloudfront distribution is disabled for async processing
```
* adds support for disabling cloudfront distributions
* adds support for deleting route53 records
* updates the rollback function on website create to disable cloudfront distributions on failure