### PR TITLE
Add background cleaner for orphan distributions

### DIFF
--- a/api/cleaner.go
+++ b/api/cleaner.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	log "github.com/sirupsen/logrus"
+)
+
+// cleanerInterval generates the cleaner interval from the baseInterval and a max splay
+func cleanerInterval(baseInterval, maxSplay string) (*time.Duration, error) {
+	base, err := time.ParseDuration(baseInterval)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("parsed base interval (%s) of %f seconds", baseInterval, base.Seconds())
+
+	maxs, err := time.ParseDuration(maxSplay)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("parsed max splay interval (%s) of %f seconds", maxSplay, maxs.Seconds())
+
+	r := rand.Int63n(int64(maxs))
+	interval := base + time.Duration(r)
+	log.Infof("starting cleaner with interval of %fs", interval.Seconds())
+
+	return &interval, nil
+}
+
+// run starts the cleaner and listens for a shutdown call.
+func (c *cleaner) run() {
+	ticker := time.NewTicker(5 * time.Second)
+	go func() {
+		// Loop that runs forever
+		for {
+			select {
+			case <-ticker.C:
+				err := c.action()
+				if err != nil {
+					log.Errorf("error executing cleaner: %s", err)
+				}
+			case <-c.context.Done():
+				log.Debug("shutting down cleaner timer")
+				ticker.Stop()
+				return
+			}
+			log.Debug("starting cleaner loop")
+		}
+	}()
+
+	log.Println("Cleaner Started")
+}
+
+// Action defines what the cleaner does...
+// 1. get a list of cloudfront distributions, that are disabled but deployed
+// 2. for any found distributions, check if the route53 resource record exists, bucket exists?
+// 3. delete if orphaned
+func (c *cleaner) action() error {
+	log.Debugf("starting cleanup action for account %s", c.account)
+	distributions, err := c.cloudFrontService.ListDistributionsWithFilter(c.context, func(dist *cloudfront.DistributionSummary) bool {
+		if aws.StringValue(dist.Status) == "Deployed" && !aws.BoolValue(dist.Enabled) {
+			log.Debugf("distribution %s (%s) is deployed but disabled", aws.StringValue(dist.DomainName), aws.StringValue(dist.Comment))
+			return true
+		}
+
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, dist := range distributions {
+		exists, err := c.s3Service.BucketExists(c.context, aws.StringValue(dist.DefaultCacheBehavior.TargetOriginId))
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			id := aws.StringValue(dist.Id)
+			origin := aws.StringValue(dist.DefaultCacheBehavior.TargetOriginId)
+			log.Infof("cloudfront distribution (%s) is deployed, disabled. bucket %s doesn't exist. deleting.", id, origin)
+			if err := c.cloudFrontService.DeleteDistribution(c.context, id); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -24,7 +24,6 @@ func (s *server) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
 
 	data, err := json.Marshal(struct {
 		Version    string `json:"version"`

--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -17,7 +17,7 @@ import (
 // CloudFront is a wrapper around the aws cloudfront service with some default config info
 type CloudFront struct {
 	Service         cloudfrontiface.CloudFrontAPI
-	Domains         map[string]common.Domain
+	Domains         map[string]*common.Domain
 	WebsiteEndpoint string
 }
 
@@ -57,7 +57,7 @@ func (c *CloudFront) WebsiteDomain(name string) (*common.Domain, error) {
 		return nil, errors.New("domain not found for website")
 	}
 
-	return &domain, nil
+	return domain, nil
 }
 
 // DefaultWebsiteDistributionConfig generates the cloudfront distribution configuration for an s3 website

--- a/cloudfront/cloudfront_test.go
+++ b/cloudfront/cloudfront_test.go
@@ -37,8 +37,8 @@ func TestNewSession(t *testing.T) {
 
 func TestWebsiteDomain(t *testing.T) {
 	e := NewSession(common.Account{
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},
@@ -126,8 +126,8 @@ func TestDefaultWebsiteDistributionConfig(t *testing.T) {
 	}
 
 	e := NewSession(common.Account{
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},

--- a/common/config.go
+++ b/common/config.go
@@ -24,8 +24,9 @@ type Account struct {
 	Secret                 string
 	DefaultS3BucketActions []string
 	DefaultS3ObjectActions []string
-	AccessLog              AccessLog
-	Domains                map[string]Domain
+	AccessLog              *AccessLog
+	Domains                map[string]*Domain
+	Cleaner                *Cleaner
 }
 
 // AccessLog is the configuration for a bucket's access log
@@ -38,6 +39,12 @@ type AccessLog struct {
 type Domain struct {
 	CertArn      string
 	HostedZoneID string
+}
+
+// Cleaner is the configuration for the periodic cleaner task
+type Cleaner struct {
+	Interval string
+	MaxSplay string
 }
 
 // Version carries around the API version information

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -27,8 +27,13 @@ var testConfig = []byte(
 			},
 			"domains": {
 				"example.com": {
-					"certArn": "arn:123456789:thingy"
+					"certArn": "arn:123456789:thingy",
+					"hostedZoneId": "AABBCCDDEEFF"
 				}
+			},
+			"cleaner": {
+				"interval": "300s",
+				"maxSplay": "60s"
 			}
 		  },
 		  "provider2": {
@@ -58,14 +63,19 @@ func TestReadConfig(t *testing.T) {
 				DefaultS3ObjectActions: []string{
 					"s3:*",
 				},
-				AccessLog: AccessLog{
+				AccessLog: &AccessLog{
 					Bucket: "foobucket",
 					Prefix: "spinup",
 				},
-				Domains: map[string]Domain{
-					"example.com": Domain{
-						CertArn: "arn:123456789:thingy",
+				Domains: map[string]*Domain{
+					"example.com": &Domain{
+						CertArn:      "arn:123456789:thingy",
+						HostedZoneID: "AABBCCDDEEFF",
 					},
+				},
+				Cleaner: &Cleaner{
+					Interval: "300s",
+					MaxSplay: "60s",
 				},
 			},
 			"provider2": Account{

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -62,6 +62,10 @@
       "accessLog": {
         "bucket": "my-access-logs",
         "prefix": "s3"
+      },
+      "cleaner": {
+        "interval": "1200s",
+        "maxSplay": "60s"
       }
     }
   },

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -66,6 +66,10 @@
           "certArn": "{{ .yalespace_org_arn }}",
           "hostedZoneID": "{{ .yalespace_zone_id }}"
         }
+      },
+      "cleaner": {
+        "interval": "1200s",
+        "maxSplay": "60s"
       }
     },
     "spinupsec": {

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/aws/aws-sdk-go v1.19.19 h1:2TpFyCjW5A87wxpWZxomEtS3KESIx90uZlWvWVJn3s
 github.com/aws/aws-sdk-go v1.19.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -16,6 +17,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
@@ -30,6 +32,7 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/route53/records_test.go
+++ b/route53/records_test.go
@@ -170,8 +170,8 @@ func (m *mockRoute53Client) ListResourceRecordSetsPagesWithContext(ctx aws.Conte
 func TestCreateRecord(t *testing.T) {
 	r := Route53{
 		Service: newmockRoute53Client(t, nil),
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},
@@ -289,8 +289,8 @@ func TestCreateRecord(t *testing.T) {
 func TestDeleteRecord(t *testing.T) {
 	r := Route53{
 		Service: newmockRoute53Client(t, nil),
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},
@@ -408,8 +408,8 @@ func TestDeleteRecord(t *testing.T) {
 func TestListRecords(t *testing.T) {
 	r := Route53{
 		Service: newmockRoute53Client(t, nil),
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},
@@ -476,8 +476,8 @@ func TestListRecords(t *testing.T) {
 func TestGetRecordByName(t *testing.T) {
 	r := Route53{
 		Service: newmockRoute53Client(t, nil),
-		Domains: map[string]common.Domain{
-			"hyper.converged": common.Domain{
+		Domains: map[string]*common.Domain{
+			"hyper.converged": &common.Domain{
 				CertArn: "arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555",
 			},
 		},

--- a/route53/route53.go
+++ b/route53/route53.go
@@ -13,7 +13,7 @@ import (
 // Route53 is a wrapper around the aws route53 service with some default config info
 type Route53 struct {
 	Service route53iface.Route53API
-	Domains map[string]common.Domain
+	Domains map[string]*common.Domain
 }
 
 // NewSession creates a new cloudfront session

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -26,7 +26,9 @@ func NewSession(account common.Account) S3 {
 		Region:      aws.String(account.Region),
 	}))
 	s.Service = s3.New(sess)
-	s.LoggingBucket = account.AccessLog.Bucket
-	s.LoggingBucketPrefix = account.AccessLog.Prefix
+	if account.AccessLog != nil {
+		s.LoggingBucket = account.AccessLog.Bucket
+		s.LoggingBucketPrefix = account.AccessLog.Prefix
+	}
 	return s
 }


### PR DESCRIPTION
Configures and starts a background cleaner process that checks for disabled, deployed distributions that don't have an S3 bucket and deletes them.  The process runs on a schedule with a randomized splay time to avoid multiple cleaners running at the same time.