### PR TITLE
Add support for website/cloudfront cache invalidation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,48 @@ Responds with a status code and the deleted objects
 | **409 Conflict**              | website bucket is not empty     |
 | **500 Internal Server Error** | a server error occurred         |
 
+### Partially update a website
+
+PATCH `/v1/s3/{account}/websites/{website}`
+
+#### Request
+
+```json
+{
+    "CacheInvalidation": ["/*"]
+}
+```
+
+#### Response
+
+Responds with a status code and the changes
+
+```json
+{
+    "Invalidation": {
+        "CreateTime": "2019-05-20T19:51:54.715Z",
+        "Id": "GGHHIIJJKKLLOO",
+        "InvalidationBatch": {
+            "CallerReference": "2b0fd0c2-e683-44a0-8d4d-3922e965d4a4",
+            "Paths": {
+                "Items": [
+                    "/*"
+                ],
+                "Quantity": 1
+            }
+        },
+        "Status": "Completed"
+    },
+    "Location": "https://cloudfront.amazonaws.com/2018-11-05/distribution/AABBCCDDEEFF/invalidation/GGHHIIJJKKLLOO"
+```
+
+| Response Code                 | Definition                      |  
+| ----------------------------- | --------------------------------|  
+| **200 OK**                    | deleted website                 |  
+| **400 Bad Request**           | badly formed request            |  
+| **403 Forbidden**             | you don't have access           |  
+| **404 Not Found**             | account or website not found    |  
+| **500 Internal Server Error** | a server error occurred         |
 
 ### Create a website user
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ POST /v1/s3/{account}/websites
 HEAD /v1/s3/{account}/websites/{website}
 GET /v1/s3/{account}/websites/{website}
 PUT /v1/s3/{account}/websites/{website}
+PATCH /v1/s3/{account}/websites/{website}
 DELETE /v1/s3/{account}/websites/{website}
 
 # Managing website users

--- a/api/routes.go
+++ b/api/routes.go
@@ -33,6 +33,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/websites/{website}", s.WebsiteShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/websites/{website}", s.WebsiteDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/websites/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
+	api.HandleFunc("/{account}/websites/{website}", s.WebsitePartialUpdateHandler).Methods(http.MethodPatch)
 
 	// website users handlers
 	api.HandleFunc("/{account}/websites/{bucket}/users", s.UserListHandler).Methods(http.MethodGet)

--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -83,7 +83,7 @@ func (c *CloudFront) DefaultWebsiteDistributionConfig(name string) (*cloudfront.
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
-			DefaultTTL:     aws.Int64(600),
+			DefaultTTL:     aws.Int64(3600),
 			TargetOriginId: aws.String(name),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),

--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -83,6 +83,7 @@ func (c *CloudFront) DefaultWebsiteDistributionConfig(name string) (*cloudfront.
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
+			MaxTTL:         aws.Int64(600),
 			TargetOriginId: aws.String(name),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),
@@ -90,7 +91,7 @@ func (c *CloudFront) DefaultWebsiteDistributionConfig(name string) (*cloudfront.
 			},
 			ViewerProtocolPolicy: aws.String("redirect-to-https"),
 		},
-		CallerReference:   aws.String(uuid.NewV4().String()),
+		CallerReference:   aws.String(uuid.New().String()),
 		Comment:           aws.String(name),
 		DefaultRootObject: aws.String("index.html"),
 		Enabled:           aws.Bool(true),

--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -83,7 +83,7 @@ func (c *CloudFront) DefaultWebsiteDistributionConfig(name string) (*cloudfront.
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
-			MaxTTL:         aws.Int64(600),
+			DefaultTTL:     aws.Int64(600),
 			TargetOriginId: aws.String(name),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),

--- a/cloudfront/cloudfront_test.go
+++ b/cloudfront/cloudfront_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 var testTime = time.Now()
@@ -67,7 +67,7 @@ func TestWebsiteDomain(t *testing.T) {
 }
 
 func TestDefaultWebsiteDistributionConfig(t *testing.T) {
-	callerRef := uuid.NewV4().String()
+	callerRef := uuid.New().String()
 	expected := &cloudfront.DistributionConfig{
 		Aliases: &cloudfront.Aliases{
 			Items: []*string{
@@ -83,6 +83,7 @@ func TestDefaultWebsiteDistributionConfig(t *testing.T) {
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
+			MaxTTL:         aws.Int64(600),
 			TargetOriginId: aws.String("im.hyper.converged"),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),

--- a/cloudfront/cloudfront_test.go
+++ b/cloudfront/cloudfront_test.go
@@ -3,7 +3,6 @@ package cloudfront
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/YaleSpinup/s3-api/common"
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,8 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
 	"github.com/google/uuid"
 )
-
-var testTime = time.Now()
 
 // mockCloudFrontClient is a fake cloudfront client
 type mockCloudFrontClient struct {
@@ -83,7 +80,7 @@ func TestDefaultWebsiteDistributionConfig(t *testing.T) {
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
-			DefaultTTL:     aws.Int64(600),
+			DefaultTTL:     aws.Int64(3600),
 			TargetOriginId: aws.String("im.hyper.converged"),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),

--- a/cloudfront/cloudfront_test.go
+++ b/cloudfront/cloudfront_test.go
@@ -83,7 +83,7 @@ func TestDefaultWebsiteDistributionConfig(t *testing.T) {
 				QueryString: aws.Bool(false),
 			},
 			MinTTL:         aws.Int64(0),
-			MaxTTL:         aws.Int64(600),
+			DefaultTTL:     aws.Int64(600),
 			TargetOriginId: aws.String("im.hyper.converged"),
 			TrustedSigners: &cloudfront.TrustedSigners{
 				Enabled:  aws.Bool(false),

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.19.19
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v1.7.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,11 @@ github.com/aws/aws-sdk-go v1.19.19 h1:2TpFyCjW5A87wxpWZxomEtS3KESIx90uZlWvWVJn3s
 github.com/aws/aws-sdk-go v1.19.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZsA=
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
@@ -17,7 +18,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.2 h1:awm861/B8OKDd2I/6o1dy3ra4BamzKhYOiGItCeZ740=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
@@ -27,12 +27,9 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 h1:PnBWHBf+6L0jO
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
* support PATCH for cache invalidation - note that invalidation is asynchronous and the same path(s) can be requested a bunch of times... we need to notify the user somehow that it could take 5 minutes
* change the max TTL to 10 minutes (maybe this should be an hour knowing that the invalidation is async?)