### PR TITLE
Handle default index.html for website gracefully

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -32,7 +32,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/websites/{bucket}", s.BucketHeadHandler).Methods(http.MethodHead)
 	api.HandleFunc("/{account}/websites/{website}", s.WebsiteShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/websites/{website}", s.WebsiteDeleteHandler).Methods(http.MethodDelete)
-	api.HandleFunc("/{account}/websites/{bucket}", s.BucketUpdateHandler).Methods(http.MethodPut)
+	api.HandleFunc("/{account}/websites/{website}", s.WebsiteUpdateHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/websites/{website}", s.WebsitePartialUpdateHandler).Methods(http.MethodPatch)
 
 	// website users handlers

--- a/cloudfront/cloudfront.go
+++ b/cloudfront/cloudfront.go
@@ -110,15 +110,6 @@ func (c *CloudFront) DefaultWebsiteDistributionConfig(name string) (*cloudfront.
 			Quantity: aws.Int64(1),
 		},
 		PriceClass: aws.String("PriceClass_100"),
-		Restrictions: &cloudfront.Restrictions{
-			GeoRestriction: &cloudfront.GeoRestriction{
-				Items: []*string{
-					aws.String("US"),
-				},
-				Quantity:        aws.Int64(1),
-				RestrictionType: aws.String("whitelist"),
-			},
-		},
 		ViewerCertificate: &cloudfront.ViewerCertificate{
 			ACMCertificateArn:      aws.String(domain.CertArn),
 			MinimumProtocolVersion: aws.String("TLSv1.1_2016"),

--- a/cloudfront/cloudfront_test.go
+++ b/cloudfront/cloudfront_test.go
@@ -107,15 +107,6 @@ func TestDefaultWebsiteDistributionConfig(t *testing.T) {
 			Quantity: aws.Int64(1),
 		},
 		PriceClass: aws.String("PriceClass_100"),
-		Restrictions: &cloudfront.Restrictions{
-			GeoRestriction: &cloudfront.GeoRestriction{
-				Items: []*string{
-					aws.String("US"),
-				},
-				Quantity:        aws.Int64(1),
-				RestrictionType: aws.String("whitelist"),
-			},
-		},
 		ViewerCertificate: &cloudfront.ViewerCertificate{
 			ACMCertificateArn:      aws.String("arn:aws:acm::12345678910:certificate/111111111-2222-3333-4444-555555555555"),
 			MinimumProtocolVersion: aws.String("TLSv1.1_2016"),

--- a/cloudfront/distribution.go
+++ b/cloudfront/distribution.go
@@ -83,6 +83,25 @@ func (c *CloudFront) DeleteDistribution(ctx context.Context, id string) error {
 	return nil
 }
 
+// TagDistribution updates the tags for a cloudfront distribution
+func (c *CloudFront) TagDistribution(ctx context.Context, arn string, tags *cloudfront.Tags) error {
+	if arn == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("tagging cloudfront distributions ARN: %s", arn)
+
+	_, err := c.Service.TagResourceWithContext(ctx, &cloudfront.TagResourceInput{
+		Resource: aws.String(arn),
+		Tags:     tags,
+	})
+	if err != nil {
+		return ErrCode("failed to tag cloudfront distribution ARN:"+arn, err)
+	}
+
+	return nil
+}
+
 // ListDistributions lists all cloudfront distributions.
 func (c *CloudFront) ListDistributions(ctx context.Context) ([]*cloudfront.DistributionSummary, error) {
 	distributions := []*cloudfront.DistributionSummary{}

--- a/s3/objects.go
+++ b/s3/objects.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/YaleSpinup/s3-api/apierror"
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,6 +30,60 @@ func (s *S3) CreateObject(ctx context.Context, input *s3.PutObjectInput) (*s3.Pu
 	out, err := s.Service.PutObjectWithContext(ctx, input)
 	if err != nil {
 		return nil, ErrCode("failed to create object in bucket", err)
+	}
+
+	return out, nil
+}
+
+// GetObjectTagging gets the tagging data from an object is S3
+func (s *S3) GetObjectTagging(ctx context.Context, input *s3.GetObjectTaggingInput) ([]*s3.Tag, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty input"))
+	}
+
+	if aws.StringValue(input.Bucket) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("missing bucket name"))
+	}
+
+	path := aws.StringValue(input.Key)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	log.Infof("getting object tagging for s3:%s%s", aws.StringValue(input.Bucket), path)
+
+	out, err := s.Service.GetObjectTaggingWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("failed to get tagging for object "+path, err)
+	}
+
+	return out.TagSet, nil
+}
+
+// DeleteObject deletes an object from S3
+func (s *S3) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	if input == nil {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("empty input"))
+	}
+
+	if aws.StringValue(input.Bucket) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("missing bucket name"))
+	}
+
+	if aws.StringValue(input.Key) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", errors.New("missing key name"))
+	}
+
+	path := aws.StringValue(input.Key)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	log.Infof("deleting object s3:%s%s", aws.StringValue(input.Bucket), path)
+
+	out, err := s.Service.DeleteObjectWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("failed to delete object "+path, err)
 	}
 
 	return out, nil

--- a/s3/objects_test.go
+++ b/s3/objects_test.go
@@ -14,11 +14,42 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func (m *mockS3Client) PutObjectWithContext(ctx aws.Context, input *s3.PutObjectInput, opts ...request.Option) (*s3.PutObjectOutput, error) {
+var testObjectTags = []*s3.Tag{
+	&s3.Tag{
+		Key:   aws.String("FirstName"),
+		Value: aws.String("Handsome"),
+	},
+	&s3.Tag{
+		Key:   aws.String("LastName"),
+		Value: aws.String("Dan"),
+	},
+}
+
+func (m *mockS3Client) GetObjectTaggingWithContext(ctx context.Context, input *s3.GetObjectTaggingInput, opts ...request.Option) (*s3.GetObjectTaggingOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &s3.GetObjectTaggingOutput{
+		TagSet: testObjectTags,
+	}, nil
+}
+
+func (m *mockS3Client) PutObjectWithContext(ctx context.Context, input *s3.PutObjectInput, opts ...request.Option) (*s3.PutObjectOutput, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockS3Client) DeleteObjectWithContext(ctx context.Context, input *s3.DeleteObjectInput, opts ...request.Option) (*s3.DeleteObjectOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	if aws.StringValue(input.Key) == "notfound.txt" {
+		return nil, awserr.New(s3.ErrCodeNoSuchKey, "Not Found", nil)
+	}
+	return nil, nil
 }
 
 func TestCreateObject(t *testing.T) {
@@ -101,6 +132,162 @@ func TestCreateObject(t *testing.T) {
 	// test non-aws error
 	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
 	_, err = s.CreateObject(context.TODO(), &input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
+func TestGetObjectTagging(t *testing.T) {
+	s := S3{Service: newMockS3Client(t, nil)}
+
+	expected := testObjectTags
+	input := s3.GetObjectTaggingInput{
+		Bucket: aws.String("testbucket"),
+		Key:    aws.String("index.html"),
+	}
+	// test success
+	out, err := s.GetObjectTagging(context.TODO(), &input)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	input = s3.GetObjectTaggingInput{
+		Bucket: aws.String("testbucket"),
+		Key:    aws.String("/index.html"),
+	}
+
+	// test success
+	out, err = s.GetObjectTagging(context.TODO(), &input)
+	if err != nil {
+		t.Errorf("expected nil error, got: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected %+v, got %+v", expected, out)
+	}
+
+	// test ErrCodeNoSuchBucket
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchBucket, "not found", nil)
+	_, err = s.GetObjectTagging(context.TODO(), &input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeNoSuchKey
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchKey, "not found", nil)
+	_, err = s.GetObjectTagging(context.TODO(), &input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
+	_, err = s.GetObjectTagging(context.TODO(), &input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrInternalError {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+}
+
+func TestDeleteObject(t *testing.T) {
+	s := S3{Service: newMockS3Client(t, nil)}
+	input := &s3.DeleteObjectInput{
+		Bucket: aws.String("testBucket"),
+		Key:    aws.String("index.html"),
+	}
+
+	// test success
+	_, err := s.DeleteObject(context.TODO(), input)
+	if err != nil {
+		t.Errorf("expected nil error for delete, got %s", err)
+	}
+
+	input = &s3.DeleteObjectInput{
+		Bucket: aws.String("testBucket"),
+		Key:    aws.String("/index.html"),
+	}
+
+	// test success with / prefix
+	_, err = s.DeleteObject(context.TODO(), input)
+	if err != nil {
+		t.Errorf("expected nil error for delete, got %s", err)
+	}
+
+	// test nil input
+	_, err = s.DeleteObject(context.TODO(), nil)
+	if err == nil {
+		t.Error("expected error for delete, got nil")
+	}
+
+	// test missing bucket input
+	_, err = s.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Key: aws.String("index.html"),
+	})
+	if err == nil {
+		t.Error("expected error for delete, got nil")
+	}
+
+	// test missing key input
+	_, err = s.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket: aws.String("testBucket"),
+	})
+	if err == nil {
+		t.Error("expected error for delete, got nil")
+	}
+
+	// test not found key input
+	_, err = s.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket: aws.String("testBucket"),
+		Key:    aws.String("notfound.txt"),
+	})
+	if err == nil {
+		t.Error("expected error for delete, got nil")
+	}
+
+	// test ErrCodeNoSuchBucket
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchBucket, "not found", nil)
+	_, err = s.DeleteObject(context.TODO(), input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test ErrCodeNoSuchKey
+	s.Service.(*mockS3Client).err = awserr.New(s3.ErrCodeNoSuchKey, "not found", nil)
+	_, err = s.DeleteObject(context.TODO(), input)
+	if aerr, ok := err.(apierror.Error); ok {
+		if aerr.Code != apierror.ErrNotFound {
+			t.Errorf("expected error code %s, got: %s", apierror.ErrNotFound, aerr.Code)
+		}
+	} else {
+		t.Errorf("expected apierror.Error, got: %s", reflect.TypeOf(err).String())
+	}
+
+	// test non-aws error
+	s.Service.(*mockS3Client).err = errors.New("things blowing up!")
+	_, err = s.DeleteObject(context.TODO(), input)
 	if aerr, ok := err.(apierror.Error); ok {
 		if aerr.Code != apierror.ErrInternalError {
 			t.Errorf("expected error code %s, got: %s", apierror.ErrInternalError, aerr.Code)


### PR DESCRIPTION
Earlier, we added support for a default `index.html` when creating a static site.  This introduced a situation where a user could create a website but then not be able to delete it without setting up the AWS CLI or some other means that might be beyond their ability.  This PR makes the API treat the default `index.html` transparently.

* Add support for deleting s3 objects
* Add support for getting the tag information for an object
* Add support for a filtering function for the results when checking if a bucket is empty
* Account for default index.html when checking if bucket is empty
* Delete default index.html when deleting a website