### PR TITLE
Limit cleanup tasks to only our "org"

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,6 @@ DELETE `/v1/s3/{account}/websites/{website}/users/{user}`
 
 *See [Delete a bucket user](#delete-a-bucket-user)*
 
-
 ## Author
 
 E Camden Fisher <camden.fisher@yale.edu>

--- a/api/handlers_buckets.go
+++ b/api/handlers_buckets.go
@@ -53,6 +53,12 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// append org tag that will get applied to all resources that tag
+	req.Tags = append(req.Tags, &s3.Tag{
+		Key:   aws.String("spinup:org"),
+		Value: aws.String(Org),
+	})
+
 	// setup err var, rollback function list and defer execution, note that we depend on the err variable defined above this
 	var rollBackTasks []func() error
 	defer func() {
@@ -434,6 +440,12 @@ func (s *server) BucketUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
 		return
 	}
+
+	// append org tag that will get applied to all resources that tag
+	req.Tags = append(req.Tags, &s3.Tag{
+		Key:   aws.String("spinup:org"),
+		Value: aws.String(Org),
+	})
 
 	if len(req.Tags) > 0 {
 		err = s3Service.TagBucket(r.Context(), bucket, req.Tags)

--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -74,6 +74,12 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// append org tag that will get applied to all resources that tag
+	req.Tags = append(req.Tags, &s3.Tag{
+		Key:   aws.String("spinup:org"),
+		Value: aws.String(Org),
+	})
+
 	// setup err var, rollback function list and defer execution, note that we depend on the err variable defined above this
 	var rollBackTasks []func() error
 	defer func() {
@@ -740,6 +746,12 @@ func (s *server) WebsiteUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		handleError(w, apierror.New(apierror.ErrBadRequest, msg, err))
 		return
 	}
+
+	// append org tag that will get applied to all resources that tag
+	req.Tags = append(req.Tags, &s3.Tag{
+		Key:   aws.String("spinup:org"),
+		Value: aws.String(Org),
+	})
 
 	// find the cloudfront distribution from the website name
 	distributionSummary, err := cloudFrontService.GetDistributionByName(r.Context(), website)

--- a/cloudfront/distribution.go
+++ b/cloudfront/distribution.go
@@ -148,6 +148,8 @@ func (c *CloudFront) ListDistributionsWithFilter(ctx context.Context, filter fun
 		input.Marker = output.DistributionList.Marker
 	}
 
+	log.Debugf("returing cloudfront distributions list: %+v", distributions)
+
 	return distributions, nil
 }
 
@@ -209,4 +211,27 @@ func (c *CloudFront) InvalidateCache(ctx context.Context, id string, paths []str
 	log.Debugf("got cache invalidation output %+v", out)
 
 	return out, nil
+}
+
+// ListTags lists the tags for an ARN
+func (c *CloudFront) ListTags(ctx context.Context, arn string) ([]*cloudfront.Tag, error) {
+	if arn == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("listing tags for cloudfront resource %s", arn)
+
+	out, err := c.Service.ListTagsForResourceWithContext(ctx, &cloudfront.ListTagsForResourceInput{Resource: aws.String(arn)})
+	if err != nil {
+		return nil, ErrCode("failed to invalidate cloudfront distributions", err)
+	}
+
+	log.Debugf("got tags list output for resource %s: %+v", arn, out)
+
+	tags := []*cloudfront.Tag{}
+	if out.Tags != nil && len(out.Tags.Items) > 0 {
+		tags = out.Tags.Items
+	}
+
+	return tags, nil
 }

--- a/cloudfront/distribution.go
+++ b/cloudfront/distribution.go
@@ -223,7 +223,7 @@ func (c *CloudFront) ListTags(ctx context.Context, arn string) ([]*cloudfront.Ta
 
 	out, err := c.Service.ListTagsForResourceWithContext(ctx, &cloudfront.ListTagsForResourceInput{Resource: aws.String(arn)})
 	if err != nil {
-		return nil, ErrCode("failed to invalidate cloudfront distributions", err)
+		return nil, ErrCode("failed to list tags cloudfront distributions", err)
 	}
 
 	log.Debugf("got tags list output for resource %s: %+v", arn, out)

--- a/common/config.go
+++ b/common/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Token         string
 	LogLevel      string
 	Version       Version
+	Org           string
 }
 
 // Account is the configuration for an individual account

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -43,7 +43,8 @@ var testConfig = []byte(
 		  }
 		},
 		"token": "SEKRET",
-		"logLevel": "info"
+		"logLevel": "info",
+		"org": "test"
 	}`)
 
 var brokenConfig = []byte(`{ "foobar": { "baz": "biz" }`)
@@ -86,6 +87,7 @@ func TestReadConfig(t *testing.T) {
 		},
 		Token:    "SEKRET",
 		LogLevel: "info",
+		Org:      "test",
 	}
 
 	actualConfig, err := ReadConfig(bytes.NewReader(testConfig))

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -70,5 +70,6 @@
     }
   },
   "token": "xxxxxx",
-  "logLevel": "info"
+  "logLevel": "info",
+  "org": "localdev"
 }

--- a/docker/config.deco.json
+++ b/docker/config.deco.json
@@ -131,5 +131,6 @@
     }
   },
   "token": "{{ .api_token }}",
-  "logLevel": "{{ .log_level }}"
+  "logLevel": "{{ .log_level }}",
+  "org": "{{ .spinup_org }}"
 }


### PR DESCRIPTION
* add org tag to all cloudfront distributions
* add ListTags func
* only cleanup distributions in the org

This will require tagging of existing distributions with an Org, but there are only a few right now.