### PR TITLE
Custom S3 endpoints, retry for bucket creation

### DIFF
--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/YaleSpinup/s3-api/apierror"
 	"github.com/aws/aws-sdk-go/aws"
@@ -112,6 +113,23 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	// wait for the bucket to exist
+	err = retry(3, 2*time.Second, func() error {
+		log.Infof("checking if bucket exists before continuing: %s", bucketName)
+		exists, err := s3Service.BucketExists(r.Context(), bucketName)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			log.Infof("bucket %s exists", bucketName)
+			return nil
+		}
+
+		msg := fmt.Sprintf("s3 bucket (%s) doesn't exist", bucketName)
+		return errors.New(msg)
+	})
 
 	err = s3Service.TagBucket(r.Context(), bucketName, req.Tags)
 	if err != nil {

--- a/api/server.go
+++ b/api/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"math/rand"
 	"time"
 
 	"github.com/YaleSpinup/s3-api/cloudfront"
@@ -17,6 +18,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 type server struct {
 	s3Services         map[string]s3.S3
@@ -148,4 +153,30 @@ func rollBack(t *[]func() error) {
 			log.Errorf("rollback task error: %s, continuing rollback", funcerr)
 		}
 	}
+}
+
+type stop struct {
+	error
+}
+
+// https://upgear.io/blog/simple-golang-retry-function/
+func retry(attempts int, sleep time.Duration, f func() error) error {
+	if err := f(); err != nil {
+		if s, ok := err.(stop); ok {
+			// Return the original error for later checking
+			return s.error
+		}
+
+		if attempts--; attempts > 0 {
+			// Add some randomness to prevent creating a Thundering Herd
+			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			sleep = sleep + jitter/2
+
+			time.Sleep(sleep)
+			return retry(attempts, 2*sleep, f)
+		}
+		return err
+	}
+
+	return nil
 }

--- a/api/server.go
+++ b/api/server.go
@@ -3,9 +3,9 @@ package api
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"net/http"
 	"os"
-	"math/rand"
 	"time"
 
 	"github.com/YaleSpinup/s3-api/cloudfront"
@@ -159,7 +159,7 @@ type stop struct {
 	error
 }
 
-// https://upgear.io/blog/simple-golang-retry-function/
+// retry is stolen from https://upgear.io/blog/simple-golang-retry-function/
 func retry(attempts int, sleep time.Duration, f func() error) error {
 	if err := f(); err != nil {
 		if s, ok := err.(stop); ok {

--- a/common/config.go
+++ b/common/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 // Account is the configuration for an individual account
 type Account struct {
+	Endpoint               string
 	Region                 string
 	Akid                   string
 	Secret                 string

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -67,6 +67,18 @@
         "interval": "1200s",
         "maxSplay": "60s"
       }
+    },
+    "someotherservice": {
+      "region": "us-middle-earth",
+      "endpoint": "https://foo.s3svc.example.com",
+      "akid": "xxxxxxxxxxxxxxxxxxxxxxxx",
+      "secret": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+      "defaultS3BucketActions": [
+        "s3:*"
+      ],
+      "defaultS3ObjectActions": [
+        "s3:*"
+      ]
     }
   },
   "token": "xxxxxx",

--- a/s3/errors.go
+++ b/s3/errors.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func ErrCode(msg string, err error) error {
@@ -21,7 +22,10 @@ func ErrCode(msg string, err error) error {
 			"AllAccessDisabled",
 
 			// Access forbidden.
-			"Forbidden":
+			"Forbidden",
+
+			// The AWS access key ID you provided does not exist in our records.
+			"InvalidAccessKeyId":
 
 			return apierror.New(apierror.ErrForbidden, msg, aerr)
 		case
@@ -271,9 +275,6 @@ func ErrCode(msg string, err error) error {
 
 			return apierror.New(apierror.ErrLimitExceeded, msg, aerr)
 		case
-			// The AWS access key ID you provided does not exist in our records.
-			"InvalidAccessKeyId",
-
 			// All access to this object has been disabled. Please contact AWS Support for further assistance.
 			"InvalidPayer",
 
@@ -311,5 +312,6 @@ func ErrCode(msg string, err error) error {
 		}
 	}
 
+	log.Warnf("uncaught error: %s, returning Internal Server Error", err)
 	return apierror.New(apierror.ErrInternalError, msg, err)
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -19,12 +19,19 @@ type S3 struct {
 
 // NewSession creates a new S3 session
 func NewSession(account common.Account) S3 {
-	s := S3{}
 	log.Infof("creating new aws session for S3 with key id %s in region %s", account.Akid, account.Region)
-	sess := session.Must(session.NewSession(&aws.Config{
+
+	s := S3{}
+	config := aws.Config{
 		Credentials: credentials.NewStaticCredentials(account.Akid, account.Secret, ""),
 		Region:      aws.String(account.Region),
-	}))
+	}
+
+	if account.Endpoint != "" {
+		config.Endpoint = aws.String(account.Endpoint)
+	}
+
+	sess := session.Must(session.NewSession(&config))
 	s.Service = s3.New(sess)
 	if account.AccessLog != nil {
 		s.LoggingBucket = account.AccessLog.Bucket


### PR DESCRIPTION
* Add custom s3 endpoints to the config so we can support third-party s3 compatible services
* Add retry logic for bucket creation to avoid failures when bucket is slow to create