### PR TITLE
Retry tagging of buckets/websites

### DIFF
--- a/api/handlers_buckets.go
+++ b/api/handlers_buckets.go
@@ -89,7 +89,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
 	// wait for the bucket to exist
-	err = retry(3, 2*time.Second, func() error {
+	err = retry(5, 2*time.Second, func() error {
 		log.Infof("checking if bucket exists before continuing: %s", bucketName)
 		exists, err := s3Service.BucketExists(r.Context(), bucketName)
 		if err != nil {
@@ -111,7 +111,15 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s3Service.TagBucket(r.Context(), bucketName, req.Tags)
+	// retry tagging
+	err = retry(5, 2*time.Second, func() error {
+		if err := s3Service.TagBucket(r.Context(), bucketName, req.Tags); err != nil {
+			log.Warnf("error tagging website bucket %s: %s", bucketName, err)
+			return err
+		}
+		return nil
+	})
+
 	if err != nil {
 		msg := fmt.Sprintf("failed to tag bucket %s: %s", bucketName, err.Error())
 		handleError(w, errors.Wrap(err, msg))

--- a/api/handlers_buckets.go
+++ b/api/handlers_buckets.go
@@ -89,7 +89,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
 	// wait for the bucket to exist
-	err = retry(5, 2*time.Second, func() error {
+	err = retry(3, 2*time.Second, func() error {
 		log.Infof("checking if bucket exists before continuing: %s", bucketName)
 		exists, err := s3Service.BucketExists(r.Context(), bucketName)
 		if err != nil {
@@ -112,7 +112,7 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// retry tagging
-	err = retry(5, 2*time.Second, func() error {
+	err = retry(3, 2*time.Second, func() error {
 		if err := s3Service.TagBucket(r.Context(), bucketName, req.Tags); err != nil {
 			log.Warnf("error tagging website bucket %s: %s", bucketName, err)
 			return err

--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -117,7 +117,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
 	// wait for the bucket to exist
-	err = retry(5, 2*time.Second, func() error {
+	err = retry(3, 2*time.Second, func() error {
 		log.Infof("checking if bucket exists before continuing: %s", bucketName)
 		exists, err := s3Service.BucketExists(r.Context(), bucketName)
 		if err != nil {
@@ -134,7 +134,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// retry tagging
-	err = retry(5, 2*time.Second, func() error {
+	err = retry(3, 2*time.Second, func() error {
 		if err := s3Service.TagBucket(r.Context(), bucketName, req.Tags); err != nil {
 			log.Warnf("error tagging website bucket %s: %s", bucketName, err)
 			return err

--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -117,7 +117,7 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
 	// wait for the bucket to exist
-	err = retry(3, 2*time.Second, func() error {
+	err = retry(5, 2*time.Second, func() error {
 		log.Infof("checking if bucket exists before continuing: %s", bucketName)
 		exists, err := s3Service.BucketExists(r.Context(), bucketName)
 		if err != nil {
@@ -133,9 +133,17 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return errors.New(msg)
 	})
 
-	err = s3Service.TagBucket(r.Context(), bucketName, req.Tags)
+	// retry tagging
+	err = retry(5, 2*time.Second, func() error {
+		if err := s3Service.TagBucket(r.Context(), bucketName, req.Tags); err != nil {
+			log.Warnf("error tagging website bucket %s: %s", bucketName, err)
+			return err
+		}
+		return nil
+	})
+
 	if err != nil {
-		msg := fmt.Sprintf("failed to tag bucket %s: %s", bucketName, err.Error())
+		msg := fmt.Sprintf("failed to tag website bucket %s: %s", bucketName, err.Error())
 		handleError(w, errors.Wrap(err, msg))
 		return
 	}


### PR DESCRIPTION
I've been unable to reproduce the tagging failures for buckets, but I think it's a result of the state where the bucket exists for the "HeadBucket" operation, but doesn't exist for the "TagBucket" operation.  I've added a retry to the TagBucket operation to try to resolve this... at worst this could cause the UI to timeout when talking to the API but I don't think its likely.