### PR TITLE
Bug fix for s3 static websites

### DIFF
--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -110,6 +110,16 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Update public access for s3 website bucket
+	if _, err = s3Service.SetPublicAccessBlock(r.Context(), &s3.PutPublicAccessBlockInput{
+		Bucket:                         aws.String(bucketName),
+		PublicAccessBlockConfiguration: &s3.PublicAccessBlockConfiguration{BlockPublicPolicy: aws.Bool(false)},
+	}); err != nil {
+		msg := fmt.Sprintf("failed to set bucket access to public for %s", bucketName)
+		handleError(w, errors.Wrap(err, msg))
+		return
+	}
+
 	// append bucket delete to rollback tasks
 	rbfunc := func(ctx context.Context) error {
 		err := s3Service.DeleteEmptyBucket(r.Context(), &s3.DeleteBucketInput{Bucket: aws.String(bucketName)})

--- a/s3/buckets.go
+++ b/s3/buckets.go
@@ -60,6 +60,18 @@ func (s *S3) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3
 	return output, nil
 }
 
+// SetPublicAccessBlock this sets the public access block on a s3 bucket (mainly used for static websites)
+func (s *S3) SetPublicAccessBlock(ctx context.Context, input *s3.PutPublicAccessBlockInput) (*s3.PutPublicAccessBlockOutput, error) {
+	log.Infof("setting public access: %+v", input)
+
+	output, err := s.Service.PutPublicAccessBlockWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("failed to set public access", err)
+	}
+
+	return output, nil
+}
+
 // DeleteEmptyBucket handles deleting an empty bucket
 func (s *S3) DeleteEmptyBucket(ctx context.Context, input *s3.DeleteBucketInput) error {
 	if input == nil || aws.StringValue(input.Bucket) == "" {


### PR DESCRIPTION
Fixes a bug introduced by amazon due to a feature change. Allows for setting the BlockPublicPolicy via the PublicAccessBlock. The fix is to set the BlockPublicPolicy to false after bucket creation but prior to attempting to update the buckets policy.