### PR TITLE
Bugfix: Show Bucket Users

### DIFF
--- a/api/handlers_users.go
+++ b/api/handlers_users.go
@@ -438,7 +438,6 @@ func (s *server) UserShowHandler(w http.ResponseWriter, r *http.Request) {
 	accountId := s.mapAccountNumber(vars["account"])
 	bucket := vars["bucket"]
 	user := vars["user"]
-	path := iamapi.GetUsernamePath(bucket, user)
 
 	role := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, s.session.RoleName)
 	policy, err := generatePolicy("iam:*")
@@ -465,9 +464,7 @@ func (s *server) UserShowHandler(w http.ResponseWriter, r *http.Request) {
 	// collect the list of users in the various management groups
 	users := []*iam.User{}
 	for _, g := range []string{"BktAdmGrp", "BktRWGrp", "BktROGrp"} {
-		log.Debugf("formatting group name with parts | bucket: %s, path: %s, group: %s", bucket, path, g)
-		groupName := iamapi.FormatGroupName(bucket, path, g)
-		log.Debugf("list group users for group name: %s", groupName)
+		groupName := fmt.Sprintf("%s-%s", bucket, g)
 		grpUsers, err := iamService.ListGroupUsers(r.Context(), &iam.GetGroupInput{GroupName: aws.String(groupName)})
 		if err != nil {
 			log.Warnf("error getting users for the %s goup", groupName)

--- a/api/routes.go
+++ b/api/routes.go
@@ -40,7 +40,7 @@ func (s *server) routes() {
 	// website users handlers
 	api.HandleFunc("/{account}/websites/{bucket}/users", s.UserListHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/websites/{website}/users", s.WebsiteUserCreateHandler).Methods(http.MethodPost)
-	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.UserShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.WebsiteUserShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.UserDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/websites/{bucket}/users/{user}", s.UserUpdateKeyHandler).Methods(http.MethodPut)
 }


### PR DESCRIPTION
* A recent change made for websites broke the functionality for showing users in buckets that had dashes in their names due to functionality for splitting scoped users in websites being reused in the same bucket users call
* **Fix:** Add new handler for website user show, remove offending code in original method 