### PR TITLE
Fix List Groups

### DIFF
--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -645,7 +645,7 @@ func (s *server) WebsiteDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	var deletedPolicies []*string
 	var users []*iam.User
 
-	foundGroups, err := iamService.ListGroups(r.Context(), &iam.ListGroupsInput{}, website)
+	foundGroups, err := iamService.ListGroups(r.Context(), &iam.ListGroupsInput{MaxItems: aws.Int64(1000)}, website)
 	if err != nil {
 		log.Errorf("there was an error listing groups %s", err)
 	}


### PR DESCRIPTION
When deleting a website the required groups, users, and policies are not deleting. ListGroups by default returns a max of 100, so if the website bucket name was not in that first 100 the groups would remain

* Added MaxItems: aws.Int64(1000) to the ListGroupsInput in the WebsiteDeleteHandler.