### PR TITLE
Migrate S3 access control from IAM Groups to per-user inline policies

### DIFF
--- a/api/handlers_buckets.go
+++ b/api/handlers_buckets.go
@@ -23,10 +23,8 @@ import (
 // failure.  The operations are
 // 1. create the bucket with the given name
 // 2. tag the bucket with given tags
-// 3. generate the default admin bucket policy
-// 4. create the admin bucket policy
-// 5. create the bucket admin group, '<bucketName>-BktAdmGrp'
-// 6. attach the bucket admin policy to the bucket admin group
+// 3. configure lifecycle, encryption, and logging
+// Note: IAM policies are now attached as inline policies when users are created (see UserCreateHandler)
 // Note: this does _not_ create any users for managing the bucket
 func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
@@ -53,7 +51,6 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s3Service := s3api.NewSession(session.Session, s.account, s.mapToAccountName(accountId))
-	iamService := iamapi.NewSession(session.Session, s.account)
 
 	var req struct {
 		Tags        []*s3.Tag
@@ -187,69 +184,10 @@ func (s *server) BucketCreateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// build the default IAM bucket admin policy (from the config and known inputs)
-	var defaultPolicy []byte
-	if defaultPolicy, err = iamService.DefaultBucketAdminPolicy(aws.String(bucketName)); err != nil {
-		msg := fmt.Sprintf("failed creating default IAM policy for bucket %s: %s", bucketName, err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	var iamPolicy *iam.Policy
-	if iamPolicy, err = iamService.CreatePolicy(r.Context(), &iam.CreatePolicyInput{
-		Description:    aws.String(fmt.Sprintf("Admin policy for %s bucket", bucketName)),
-		PolicyDocument: aws.String(string(defaultPolicy)),
-		PolicyName:     aws.String(fmt.Sprintf("%s-BktAdmPlc", bucketName)),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create policy: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append policy delete to rollback tasks
-	rollBackTasks = append(rollBackTasks, func(ctx context.Context) error {
-		if err := iamService.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: iamPolicy.Arn}); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	groupName := fmt.Sprintf("%s-BktAdmGrp", bucketName)
-
-	var group *iam.Group
-	if group, err = iamService.CreateGroup(r.Context(), &iam.CreateGroupInput{
-		GroupName: aws.String(groupName),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create group: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append group delete to rollback tasks
-	rollBackTasks = append(rollBackTasks, func(ctx context.Context) error {
-		if err := iamService.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {
-			return err
-		}
-		return nil
-	})
-
-	if err = iamService.AttachGroupPolicy(r.Context(), &iam.AttachGroupPolicyInput{
-		GroupName: aws.String(groupName),
-		PolicyArn: iamPolicy.Arn,
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create group: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
 	output := struct {
 		Bucket *string
-		Policy *iam.Policy
-		Group  *iam.Group
 	}{
 		bucketOutput.Location,
-		iamPolicy,
-		group,
 	}
 
 	j, err := json.Marshal(output)
@@ -361,9 +299,8 @@ func (s *server) BucketHeadHandler(w http.ResponseWriter, r *http.Request) {
 
 // BucketDeleteHandler deletes an empty bucket and all of it's dependencies.  The operations are
 // 1. the bucket is deleted, this will fail if the bucket is not empty
-// 2. a list of policies attached to the bucket admin group (<bucketName>-BktAdmGrp) is gathered
-// 3. each of those policies is detached from the group and if it starts with '<bucketName>-', it is deleted
-// 4. the bucket admin group is deleted
+// 2. (legacy) group-based cleanup: detach/delete policies, remove users from groups, delete groups
+// 3. (new) inline-policy-based cleanup: find users by prefix, delete inline policies, access keys, and users
 func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -399,10 +336,10 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// --- Legacy group-based cleanup ---
 	for _, g := range []string{"BktAdmGrp", "BktRWGrp", "BktROGrp"} {
 		groupName := fmt.Sprintf("%s-%s", bucket, g)
 
-		// TODO: if this fails with a NotFound, we should continue on because its probably a legacy bucket
 		policies, err := iamService.ListGroupPolicies(r.Context(), &iam.ListAttachedGroupPoliciesInput{GroupName: aws.String(groupName)})
 		if err != nil {
 			log.Warnf("failed to list group policies when deleting bucket %s: %s", bucket, err)
@@ -431,14 +368,12 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, u := range users {
-			// get a users access keys
 			keys, err := iamService.ListAccessKeys(r.Context(), &iam.ListAccessKeysInput{UserName: u.UserName})
 			if err != nil {
 				handleError(w, err)
 				return
 			}
 
-			// delete the access keys
 			for _, k := range keys {
 				err = iamService.DeleteAccessKey(r.Context(), &iam.DeleteAccessKeyInput{UserName: u.UserName, AccessKeyId: k.AccessKeyId})
 				if err != nil {
@@ -467,6 +402,69 @@ func (s *server) BucketDeleteHandler(w http.ResponseWriter, r *http.Request) {
 					log.Warnf("failed to delete user: %s, %s", aws.StringValue(u.UserName), err)
 				}
 			}
+		}
+	}
+
+	// --- New inline-policy-based cleanup ---
+	// Find users by bucket name prefix (e.g., "mybucket-")
+	inlineUsers, err := iamService.ListUsers(r.Context(), bucket+"-")
+	if err != nil {
+		log.Warnf("failed to list inline policy users for bucket %s: %s", bucket, err)
+	}
+
+	for _, u := range inlineUsers {
+		userName := aws.StringValue(u.UserName)
+
+		// Delete inline policies
+		inlinePolicies, err := iamService.ListUserInlinePolicies(r.Context(), &iam.ListUserPoliciesInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list inline policies for user %s: %s", userName, err)
+		}
+		for _, pName := range inlinePolicies {
+			if err := iamService.DeleteUserPolicy(r.Context(), &iam.DeleteUserPolicyInput{
+				UserName:   u.UserName,
+				PolicyName: pName,
+			}); err != nil {
+				log.Warnf("failed to delete inline policy %s for user %s: %s", aws.StringValue(pName), userName, err)
+			}
+		}
+
+		// Delete access keys
+		keys, err := iamService.ListAccessKeys(r.Context(), &iam.ListAccessKeysInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list access keys for user %s: %s", userName, err)
+		}
+		for _, k := range keys {
+			if err := iamService.DeleteAccessKey(r.Context(), &iam.DeleteAccessKeyInput{UserName: u.UserName, AccessKeyId: k.AccessKeyId}); err != nil {
+				log.Warnf("failed to delete access key for user %s: %s", userName, err)
+			}
+		}
+
+		// Remove from any remaining groups
+		groups, err := iamService.ListUserGroups(r.Context(), &iam.ListGroupsForUserInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list groups for user %s: %s", userName, err)
+		}
+		for _, g := range groups {
+			if err := iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{UserName: u.UserName, GroupName: g.GroupName}); err != nil {
+				log.Warnf("failed to remove user %s from group %s: %s", userName, aws.StringValue(g.GroupName), err)
+			}
+		}
+
+		// Detach managed policies
+		managedPolicies, err := iamService.ListUserPolicies(r.Context(), &iam.ListAttachedUserPoliciesInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list managed policies for user %s: %s", userName, err)
+		}
+		for _, p := range managedPolicies {
+			if err := iamService.DetachUserPolicy(r.Context(), &iam.DetachUserPolicyInput{UserName: u.UserName, PolicyArn: p.PolicyArn}); err != nil {
+				log.Warnf("failed to detach policy from user %s: %s", userName, err)
+			}
+		}
+
+		// Delete the user
+		if err := iamService.DeleteUser(r.Context(), &iam.DeleteUserInput{UserName: u.UserName}); err != nil {
+			log.Warnf("failed to delete inline policy user %s: %s", userName, err)
 		}
 	}
 

--- a/api/handlers_users.go
+++ b/api/handlers_users.go
@@ -107,44 +107,15 @@ func (s *server) UserCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
+	userName := aws.StringValue(userOutput.User.UserName)
 	for _, group := range req.Groups {
-		groupName := fmt.Sprintf("%s-%s", bucket, group)
-		_, err = iamService.GetGroup(r.Context(), groupName)
+		rbTasks, err := s.CreateBucketUserInlinePolicy(r.Context(), iamService, bucket, userName, group)
 		if err != nil {
-			if aerr, ok := err.(apierror.Error); ok && aerr.Code == apierror.ErrNotFound {
-				var rbTasks []rollbackFunc
-				rbTasks, err = s.CreateBucketGroupPolicy(r.Context(), iamService, bucket, group)
-				if err != nil {
-					handleError(w, err)
-					return
-				}
-				rollBackTasks = append(rollBackTasks, rbTasks...)
-			} else {
-				handleError(w, err)
-				return
-			}
-		}
-
-		if err = iamService.AddUserToGroup(r.Context(), &iam.AddUserToGroupInput{
-			UserName:  userOutput.User.UserName,
-			GroupName: aws.String(groupName),
-		}); err != nil {
-			msg := fmt.Sprintf("failed to add user: %s to group %s for bucket %s", aws.StringValue(userOutput.User.UserName), group, bucket)
+			msg := fmt.Sprintf("failed to attach inline policy for user %s, group %s, bucket %s: %s", userName, group, bucket, err)
 			handleError(w, errors.Wrap(err, msg))
 			return
 		}
-
-		// append detach group to rollback funciton
-		rbfunc = func(ctx context.Context) error {
-			if err := iamService.RemoveUserFromGroup(ctx, &iam.RemoveUserFromGroupInput{
-				UserName:  userOutput.User.UserName,
-				GroupName: aws.String(groupName),
-			}); err != nil {
-				return err
-			}
-			return nil
-		}
-		rollBackTasks = append(rollBackTasks, rbfunc)
+		rollBackTasks = append(rollBackTasks, rbTasks...)
 	}
 
 	output := struct {
@@ -227,7 +198,21 @@ func (s *server) UserDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// get a list of all of the attached user policies for a user.  this should be empty for "new" s3 buckets, but buckets created
+	// delete inline policies (new model)
+	inlinePolicies, err := iamService.ListUserInlinePolicies(r.Context(), &iam.ListUserPoliciesInput{UserName: aws.String(user)})
+	if err != nil {
+		log.Warnf("failed to list inline policies for user %s: %s", user, err)
+	}
+	for _, pName := range inlinePolicies {
+		if err := iamService.DeleteUserPolicy(r.Context(), &iam.DeleteUserPolicyInput{
+			UserName:   aws.String(user),
+			PolicyName: pName,
+		}); err != nil {
+			log.Warnf("failed to delete inline policy %s for user %s: %s", aws.StringValue(pName), user, err)
+		}
+	}
+
+	// get a list of all of the attached managed user policies.  this should be empty for "new" s3 buckets, but buckets created
 	// with the legacy service have the policy directly attached to the user with the same name as the user/bucket
 	policies, err := iamService.ListUserPolicies(r.Context(), &iam.ListAttachedUserPoliciesInput{UserName: aws.String(user)})
 	if err != nil {
@@ -235,7 +220,7 @@ func (s *server) UserDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// detatch and delete all of the policies that we found if the name is the same as the bucket or if the name starts
+	// detach and delete all of the policies that we found if the name is the same as the bucket or if the name starts
 	// with the the name of the bucket
 	for _, p := range policies {
 		pname := aws.StringValue(p.PolicyName)
@@ -358,9 +343,10 @@ func (s *server) UserUpdateKeyHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(j)
 }
 
-// UserListHandler lists the users for a bucket.  It tries to return the members of the predefined
-// bucket management groups: <<bucket>>-BktAdmGrp,  <<bucket>>-BktRWGrp, <<bucket>>-BktROGrp. It also
-// looks for a user with the same name as the bucket and returns that if it exists.
+// UserListHandler lists the users for a bucket.  It discovers users via:
+// 1. (legacy) members of predefined bucket management groups: <<bucket>>-BktAdmGrp, <<bucket>>-BktRWGrp, <<bucket>>-BktROGrp
+// 2. (new) users found by prefix listing (<<bucket>>-)
+// 3. a user with the same name as the bucket (legacy support)
 func (s *server) UserListHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -406,9 +392,15 @@ func (s *server) UserListHandler(w http.ResponseWriter, r *http.Request) {
 		users = append(users, u...)
 	}
 
+	// discover users by prefix (new inline policy model)
+	prefixUsers, err := iamService.ListUsers(r.Context(), bucket+"-")
+	if err != nil {
+		log.Warnf("failed to list users by prefix for bucket %s: %s", bucket, err)
+	}
+	users = append(users, prefixUsers...)
+
 	// check if there is a user with the same name as the bucket to support legacy buckets
 	user, err := iamService.GetUser(r.Context(), &iam.GetUserInput{UserName: aws.String(bucket)})
-	fmt.Println(err)
 	if err == nil {
 		users = append(users, user.User)
 	}
@@ -461,7 +453,7 @@ func (s *server) UserShowHandler(w http.ResponseWriter, r *http.Request) {
 
 	iamService := iamapi.NewSession(session.Session, s.account)
 
-	// collect the list of users in the various management groups
+	// collect the list of users in the various management groups (legacy)
 	users := []*iam.User{}
 	for _, g := range []string{"BktAdmGrp", "BktRWGrp", "BktROGrp"} {
 		groupName := fmt.Sprintf("%s-%s", bucket, g)
@@ -474,20 +466,31 @@ func (s *server) UserShowHandler(w http.ResponseWriter, r *http.Request) {
 		users = append(users, grpUsers...)
 	}
 
+	// discover users by prefix (new inline policy model)
+	prefixUsers, err := iamService.ListUsers(r.Context(), bucket+"-")
+	if err != nil {
+		log.Warnf("failed to list users by prefix for bucket %s: %s", bucket, err)
+	}
+	users = append(users, prefixUsers...)
+
 	// check if there is a user with the same name as the bucket to support legacy buckets
 	u, err := iamService.GetUser(r.Context(), &iam.GetUserInput{UserName: aws.String(bucket)})
 	if err == nil {
 		users = append(users, u.User)
 	}
 
+	// remove potential duplicate users
+	users = iamapi.FilterDuplicateUsers(users)
+
 	// range over all of the users we found and return the user if it matches the requested user
 	for _, u := range users {
 		if aws.StringValue(u.UserName) == user {
 			var userDetails = struct {
-				User       *iam.User
-				AccessKeys []*iam.AccessKeyMetadata
-				Groups     []*iam.Group
-				Policies   []*iam.AttachedPolicy
+				User           *iam.User
+				AccessKeys     []*iam.AccessKeyMetadata
+				Groups         []*iam.Group
+				Policies       []*iam.AttachedPolicy
+				InlinePolicies []*string
 			}{
 				User: u,
 			}
@@ -512,6 +515,12 @@ func (s *server) UserShowHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			userDetails.Policies = policies
+
+			inlinePolicies, err := iamService.ListUserInlinePolicies(r.Context(), &iam.ListUserPoliciesInput{UserName: aws.String(user)})
+			if err != nil {
+				log.Warnf("failed to list inline policies for user %s: %s", user, err)
+			}
+			userDetails.InlinePolicies = inlinePolicies
 
 			j, err := json.Marshal(userDetails)
 			if err != nil {

--- a/api/handlers_website.go
+++ b/api/handlers_website.go
@@ -30,14 +30,10 @@ import (
 // 1. create the bucket with the given name
 // 2. tag the bucket with given tags
 // 3. apply the website configuration to the bucket
-// 4. generate the default admin bucket policy
-// 5. create the admin bucket policy
-// 6. create the bucket admin group, '<bucketName>-BktAdmGrp'
-// 7. attach the bucket admin policy to the bucket admin group
-// 8. create cloudfront distribution with s3 website origin (for https)
-// 9. create the web admin group, '<bucketName>-WebAdmGrp'
-// 10. attach the web admin policy to the web admin group
-// 11. create alias record in route53
+// 4. set the S3 bucket policy for public website access
+// 5. create cloudfront distribution with s3 website origin (for https)
+// 6. create alias record in route53
+// Note: IAM policies are now attached as inline policies when users are created
 // Note: this does _not_ create any users for managing the bucket
 func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
@@ -211,67 +207,6 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// build the default IAM bucket admin policy (from the config and known inputs)
-	var defaultBktPolicy []byte
-	if defaultBktPolicy, err = iamService.DefaultBucketAdminPolicy(aws.String(bucketName)); err != nil {
-		msg := fmt.Sprintf("failed building default IAM policy for bucket %s: %s", bucketName, err.Error())
-		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
-		return
-	}
-
-	var bktPolicy *iam.Policy
-	if bktPolicy, err = iamService.CreatePolicy(r.Context(), &iam.CreatePolicyInput{
-		Description:    aws.String(fmt.Sprintf("Admin policy for %s bucket", bucketName)),
-		PolicyDocument: aws.String(string(defaultBktPolicy)),
-		PolicyName:     aws.String(fmt.Sprintf("%s-BktAdmPlc", bucketName)),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create bucket admin policy: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append policy delete to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		err := iamService.DeletePolicy(r.Context(), &iam.DeletePolicyInput{PolicyArn: bktPolicy.Arn})
-		return err
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
-	bktGroupName := fmt.Sprintf("%s-BktAdmGrp", bucketName)
-
-	var bktGroup *iam.Group
-	if bktGroup, err = iamService.CreateGroup(r.Context(), &iam.CreateGroupInput{
-		GroupName: aws.String(bktGroupName),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create bucket admin group: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append group delete to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		return iamService.DeleteGroup(r.Context(), &iam.DeleteGroupInput{GroupName: aws.String(bktGroupName)})
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
-	if err = iamService.AttachGroupPolicy(r.Context(), &iam.AttachGroupPolicyInput{
-		GroupName: aws.String(bktGroupName),
-		PolicyArn: bktPolicy.Arn,
-	}); err != nil {
-		msg := fmt.Sprintf("failed to attach policy %s to group %s: %s", aws.StringValue(bktPolicy.Arn), bktGroupName, err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append detach group policy to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		return iamService.DetachGroupPolicy(r.Context(), &iam.DetachGroupPolicyInput{
-			GroupName: aws.String(bktGroupName),
-			PolicyArn: bktPolicy.Arn,
-		})
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
 	// normalize tags
 	cfTags := []*cloudfront.Tag{}
 	for _, tag := range req.Tags {
@@ -300,66 +235,6 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	rbfunc = func(ctx context.Context) error {
 		_, err := cloudFrontService.DisableDistribution(r.Context(), aws.StringValue(distribution.Id))
 		return err
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
-	// build the default IAM web admin policy (from the config and known inputs)
-	var defaultWebPolicy []byte
-	if defaultWebPolicy, err = iamService.DefaultWebAdminPolicy(distribution.ARN); err != nil {
-		msg := fmt.Sprintf("failed building default IAM policy for cloudfront distribution %s: %s", aws.StringValue(distribution.ARN), err.Error())
-		handleError(w, apierror.New(apierror.ErrInternalError, msg, err))
-		return
-	}
-
-	var webPolicy *iam.Policy
-	if webPolicy, err = iamService.CreatePolicy(r.Context(), &iam.CreatePolicyInput{
-		Description:    aws.String(fmt.Sprintf("Admin policy for %s web distribution", bucketName)),
-		PolicyDocument: aws.String(string(defaultWebPolicy)),
-		PolicyName:     aws.String(fmt.Sprintf("%s-WebAdmPlc", bucketName)),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create web admin policy: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append policy delete to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		return iamService.DeletePolicy(r.Context(), &iam.DeletePolicyInput{PolicyArn: webPolicy.Arn})
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
-	webGroupName := fmt.Sprintf("%s-WebAdmGrp", bucketName)
-
-	var webGroup *iam.Group
-	if webGroup, err = iamService.CreateGroup(r.Context(), &iam.CreateGroupInput{
-		GroupName: aws.String(webGroupName),
-	}); err != nil {
-		msg := fmt.Sprintf("failed to create web admin group: %s", err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append group delete to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		return iamService.DeleteGroup(r.Context(), &iam.DeleteGroupInput{GroupName: aws.String(webGroupName)})
-	}
-	rollBackTasks = append(rollBackTasks, rbfunc)
-
-	if err = iamService.AttachGroupPolicy(r.Context(), &iam.AttachGroupPolicyInput{
-		GroupName: aws.String(webGroupName),
-		PolicyArn: webPolicy.Arn,
-	}); err != nil {
-		msg := fmt.Sprintf("failed to attach policy %s to group %s: %s", aws.StringValue(bktPolicy.Arn), webGroupName, err.Error())
-		handleError(w, errors.Wrap(err, msg))
-		return
-	}
-
-	// append detach group policy to rollback tasks
-	rbfunc = func(ctx context.Context) error {
-		return iamService.DetachGroupPolicy(r.Context(), &iam.DetachGroupPolicyInput{
-			GroupName: aws.String(webGroupName),
-			PolicyArn: webPolicy.Arn,
-		})
 	}
 	rollBackTasks = append(rollBackTasks, rbfunc)
 
@@ -394,14 +269,10 @@ func (s *server) CreateWebsiteHandler(w http.ResponseWriter, r *http.Request) {
 
 	output := struct {
 		Bucket       *string
-		Policies     []*iam.Policy
-		Groups       []*iam.Group
 		Distribution *cloudfront.Distribution
 		DnsChange    *route53.ChangeInfo
 	}{
 		bucketOutput.Location,
-		[]*iam.Policy{bktPolicy, webPolicy},
-		[]*iam.Group{bktGroup, webGroup},
 		distribution,
 		dnsChange,
 	}
@@ -547,14 +418,10 @@ func (s *server) WebsiteShowHandler(w http.ResponseWriter, r *http.Request) {
 
 // WebsiteDeleteHandler deletes all of the resources for a static website.  The operations are
 // 1. the website bucket is deleted, this will fail if the bucket is not empty
-// 2. a list of policies attached to the bucket admin group (<bucketName>-BktAdmGrp) is gathered
-// 3. each of those policies is detached from the group and if it starts with '<bucketName>-', it is deleted
-// 4. the bucket admin group is deleted
-// 5. a list of policies attached to the web admin group (<bucketName>-WebAdmGrp) is gathered
-// 6. each of those policies is detached from the group and if it starts with '<bucketName>-', it is deleted
-// 7. the web admin group is deleted
-// 8. the route53 dns record is deleted
-// 9. the cloudfront distribution is disabled for async processing
+// 2. (legacy) group-based cleanup: detach/delete policies, remove users from groups, delete groups
+// 3. (new) inline-policy-based cleanup: find users by prefix, delete inline policies, access keys, and users
+// 4. the route53 dns record is deleted
+// 5. the cloudfront distribution is disabled for async processing
 func (s *server) WebsiteDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	w = LogWriter{w}
 	vars := mux.Vars(r)
@@ -735,6 +602,69 @@ func (s *server) WebsiteDeleteHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				log.Warnf("failed to delete user: %s, %s", aws.StringValue(groupUser.UserName), err)
 			}
+		}
+	}
+
+	// --- New inline-policy-based cleanup ---
+	// Find users by website name prefix (e.g., "mywebsite.example.com-")
+	inlineUsers, err := iamService.ListUsers(r.Context(), website+"-")
+	if err != nil {
+		log.Warnf("failed to list inline policy users for website %s: %s", website, err)
+	}
+
+	for _, u := range inlineUsers {
+		userName := aws.StringValue(u.UserName)
+
+		// Delete inline policies
+		inlinePolicies, err := iamService.ListUserInlinePolicies(r.Context(), &iam.ListUserPoliciesInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list inline policies for user %s: %s", userName, err)
+		}
+		for _, pName := range inlinePolicies {
+			if err := iamService.DeleteUserPolicy(r.Context(), &iam.DeleteUserPolicyInput{
+				UserName:   u.UserName,
+				PolicyName: pName,
+			}); err != nil {
+				log.Warnf("failed to delete inline policy %s for user %s: %s", aws.StringValue(pName), userName, err)
+			}
+		}
+
+		// Delete access keys
+		keys, err := iamService.ListAccessKeys(r.Context(), &iam.ListAccessKeysInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list access keys for user %s: %s", userName, err)
+		}
+		for _, k := range keys {
+			if err := iamService.DeleteAccessKey(r.Context(), &iam.DeleteAccessKeyInput{UserName: u.UserName, AccessKeyId: k.AccessKeyId}); err != nil {
+				log.Warnf("failed to delete access key for user %s: %s", userName, err)
+			}
+		}
+
+		// Remove from any remaining groups
+		userGroups, err := iamService.ListUserGroups(r.Context(), &iam.ListGroupsForUserInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list groups for user %s: %s", userName, err)
+		}
+		for _, g := range userGroups {
+			if err := iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{UserName: u.UserName, GroupName: g.GroupName}); err != nil {
+				log.Warnf("failed to remove user %s from group %s: %s", userName, aws.StringValue(g.GroupName), err)
+			}
+		}
+
+		// Detach managed policies
+		managedPolicies, err := iamService.ListUserPolicies(r.Context(), &iam.ListAttachedUserPoliciesInput{UserName: u.UserName})
+		if err != nil {
+			log.Warnf("failed to list managed policies for user %s: %s", userName, err)
+		}
+		for _, p := range managedPolicies {
+			if err := iamService.DetachUserPolicy(r.Context(), &iam.DetachUserPolicyInput{UserName: u.UserName, PolicyArn: p.PolicyArn}); err != nil {
+				log.Warnf("failed to detach policy from user %s: %s", userName, err)
+			}
+		}
+
+		// Delete the user
+		if err := iamService.DeleteUser(r.Context(), &iam.DeleteUserInput{UserName: u.UserName}); err != nil {
+			log.Warnf("failed to delete inline policy user %s: %s", userName, err)
 		}
 	}
 

--- a/api/handlers_website_users.go
+++ b/api/handlers_website_users.go
@@ -117,58 +117,15 @@ func (s *server) WebsiteUserCreateHandler(w http.ResponseWriter, r *http.Request
 		path = aws.StringValue(req.User.Path)
 	}
 
+	userName := aws.StringValue(userOutput.User.UserName)
 	for _, group := range groupNames {
-		groupName := iamapi.FormatGroupName(website, path, group)
-
-		_, err := iamService.GetGroup(r.Context(), groupName)
+		rbTasks, err := s.CreateWebsiteUserInlinePolicy(r.Context(), iamService, website, path, userName, group)
 		if err != nil {
-			if aerr, ok := err.(apierror.Error); ok && aerr.Code == apierror.ErrNotFound {
-				var rbTasks []rollbackFunc
-				rbTasks, err = s.CreateWebsiteBucketPolicy(r.Context(), iamService, website, path, group)
-				if err != nil {
-					handleError(w, err)
-					return
-				}
-				rollBackTasks = append(rollBackTasks, rbTasks...)
-			} else {
-				handleError(w, err)
-				return
-			}
-		}
-
-		if err = iamService.AddUserToGroup(r.Context(), &iam.AddUserToGroupInput{
-			UserName:  userOutput.User.UserName,
-			GroupName: aws.String(groupName),
-		}); err != nil {
-			msg := fmt.Sprintf("failed to add user: %s to group %s for website %s", aws.StringValue(userOutput.User.UserName), group, website)
+			msg := fmt.Sprintf("failed to attach inline policy for user %s, group %s, website %s: %s", userName, group, website, err)
 			handleError(w, errors.Wrap(err, msg))
 			return
 		}
-
-		if path == "/" && group == "BktAdmGrp" {
-			webGroupName := iamapi.FormatGroupName(website, path, "WebAdmGrp")
-
-			if err = iamService.AddUserToGroup(r.Context(), &iam.AddUserToGroupInput{
-				UserName:  userOutput.User.UserName,
-				GroupName: aws.String(webGroupName),
-			}); err != nil {
-				msg := fmt.Sprintf("failed to add user: %s to group %s for website %s", aws.StringValue(userOutput.User.UserName), "WebAdmGrp", website)
-				handleError(w, errors.Wrap(err, msg))
-				return
-			}
-		}
-
-		// append detach group to rollback funciton
-		rbfunc = func(ctx context.Context) error {
-			if err := iamService.RemoveUserFromGroup(r.Context(), &iam.RemoveUserFromGroupInput{
-				UserName:  userOutput.User.UserName,
-				GroupName: aws.String(groupName),
-			}); err != nil {
-				return err
-			}
-			return nil
-		}
-		rollBackTasks = append(rollBackTasks, rbfunc)
+		rollBackTasks = append(rollBackTasks, rbTasks...)
 	}
 
 	if path != "/" {
@@ -245,7 +202,7 @@ func (s *server) WebsiteUserShowHandler(w http.ResponseWriter, r *http.Request) 
 
 	iamService := iamapi.NewSession(session.Session, s.account)
 
-	// collect the list of users in the various management groups
+	// collect the list of users in the various management groups (legacy)
 	users := []*iam.User{}
 	for _, g := range []string{"BktAdmGrp", "BktRWGrp", "BktROGrp"} {
 		log.Debugf("formatting group name with parts | bucket: %s, path: %s, group: %s", bucket, path, g)
@@ -260,20 +217,31 @@ func (s *server) WebsiteUserShowHandler(w http.ResponseWriter, r *http.Request) 
 		users = append(users, grpUsers...)
 	}
 
+	// discover users by prefix (new inline policy model)
+	prefixUsers, err := iamService.ListUsers(r.Context(), bucket+"-")
+	if err != nil {
+		log.Warnf("failed to list users by prefix for website %s: %s", bucket, err)
+	}
+	users = append(users, prefixUsers...)
+
 	// check if there is a user with the same name as the bucket to support legacy buckets
 	u, err := iamService.GetUser(r.Context(), &iam.GetUserInput{UserName: aws.String(bucket)})
 	if err == nil {
 		users = append(users, u.User)
 	}
 
+	// remove potential duplicate users
+	users = iamapi.FilterDuplicateUsers(users)
+
 	// range over all of the users we found and return the user if it matches the requested user
 	for _, u := range users {
 		if aws.StringValue(u.UserName) == user {
 			var userDetails = struct {
-				User       *iam.User
-				AccessKeys []*iam.AccessKeyMetadata
-				Groups     []*iam.Group
-				Policies   []*iam.AttachedPolicy
+				User           *iam.User
+				AccessKeys     []*iam.AccessKeyMetadata
+				Groups         []*iam.Group
+				Policies       []*iam.AttachedPolicy
+				InlinePolicies []*string
 			}{
 				User: u,
 			}
@@ -298,6 +266,12 @@ func (s *server) WebsiteUserShowHandler(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 			userDetails.Policies = policies
+
+			inlinePolicies, err := iamService.ListUserInlinePolicies(r.Context(), &iam.ListUserPoliciesInput{UserName: aws.String(user)})
+			if err != nil {
+				log.Warnf("failed to list inline policies for user %s: %s", user, err)
+			}
+			userDetails.InlinePolicies = inlinePolicies
 
 			j, err := json.Marshal(userDetails)
 			if err != nil {

--- a/api/orchestration.go
+++ b/api/orchestration.go
@@ -94,6 +94,135 @@ func (s *server) CreateBucketGroupPolicy(ctx context.Context, iamService iamapi.
 	return rollBackTasks, nil
 }
 
+// CreateBucketUserInlinePolicy generates the appropriate bucket policy document based on the group
+// identifier (BktAdmGrp, BktRWGrp, BktROGrp) and attaches it as an inline policy directly to
+// the IAM user.  This replaces the group-based model to avoid the 500 IAM group limit.
+// It returns rollback functions and will rollback itself on error.
+func (s *server) CreateBucketUserInlinePolicy(ctx context.Context, iamService iamapi.IAM, bucket, userName, group string) ([]rollbackFunc, error) {
+	var err error
+	var rollBackTasks []rollbackFunc
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	var policyName string
+	var policyDocument []byte
+	switch group {
+	case "BktAdmGrp":
+		policyName = fmt.Sprintf("%s-BktAdmPlc", bucket)
+		if policyDocument, err = iamService.AdminBucketPolicy(bucket); err != nil {
+			return rollBackTasks, err
+		}
+	case "BktRWGrp":
+		policyName = fmt.Sprintf("%s-BktRWPlc", bucket)
+		if policyDocument, err = iamService.ReadWriteBucketPolicy(bucket); err != nil {
+			return rollBackTasks, err
+		}
+	case "BktROGrp":
+		policyName = fmt.Sprintf("%s-BktROPlc", bucket)
+		if policyDocument, err = iamService.ReadOnlyBucketPolicy(bucket); err != nil {
+			return rollBackTasks, err
+		}
+	default:
+		return rollBackTasks, fmt.Errorf("invalid group name: %s", group)
+	}
+
+	if err = iamService.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:       aws.String(userName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(string(policyDocument)),
+	}); err != nil {
+		return rollBackTasks, fmt.Errorf("failed to put inline policy %s for user %s: %s", policyName, userName, err)
+	}
+
+	// append inline policy delete to rollback tasks
+	rbfunc := func(ctx context.Context) error {
+		return iamService.DeleteUserPolicy(ctx, &iam.DeleteUserPolicyInput{
+			UserName:   aws.String(userName),
+			PolicyName: aws.String(policyName),
+		})
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	return rollBackTasks, nil
+}
+
+// CreateWebsiteUserInlinePolicy generates the appropriate website policy document based on the group
+// identifier (BktAdmGrp, BktRWGrp, BktROGrp) and attaches it as an inline policy directly to
+// the IAM user.  This replaces the group-based model for websites.
+func (s *server) CreateWebsiteUserInlinePolicy(ctx context.Context, iamService iamapi.IAM, website, path, userName, group string) ([]rollbackFunc, error) {
+	var err error
+	var rollBackTasks []rollbackFunc
+	defer func() {
+		if err != nil {
+			log.Errorf("recovering from error: %s, executing %d rollback tasks", err, len(rollBackTasks))
+			rollBack(&rollBackTasks)
+		}
+	}()
+
+	var policyName string
+	var policyDocument []byte
+	switch group {
+	case "BktAdmGrp":
+		policyName = iamapi.FormatGroupName(website, path, "BktAdmPlc")
+		if path != "/" {
+			if policyDocument, err = iamService.AdminBucketPolicyWithPath(website, path); err != nil {
+				return rollBackTasks, err
+			}
+		} else {
+			if policyDocument, err = iamService.AdminBucketPolicy(website); err != nil {
+				return rollBackTasks, err
+			}
+		}
+	case "BktRWGrp":
+		policyName = iamapi.FormatGroupName(website, path, "BktRWPlc")
+		if path != "/" {
+			if policyDocument, err = iamService.ReadWriteBucketPolicyWithPath(website, path); err != nil {
+				return rollBackTasks, err
+			}
+		} else {
+			if policyDocument, err = iamService.ReadWriteBucketPolicy(website); err != nil {
+				return rollBackTasks, err
+			}
+		}
+	case "BktROGrp":
+		policyName = iamapi.FormatGroupName(website, path, "BktROPlc")
+		if path != "/" {
+			if policyDocument, err = iamService.ReadOnlyBucketPolicyWithPath(website, path); err != nil {
+				return rollBackTasks, err
+			}
+		} else {
+			if policyDocument, err = iamService.ReadOnlyBucketPolicy(website); err != nil {
+				return rollBackTasks, err
+			}
+		}
+	default:
+		return rollBackTasks, fmt.Errorf("invalid group name: %s", group)
+	}
+
+	if err = iamService.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+		UserName:       aws.String(userName),
+		PolicyName:     aws.String(policyName),
+		PolicyDocument: aws.String(string(policyDocument)),
+	}); err != nil {
+		return rollBackTasks, fmt.Errorf("failed to put inline policy %s for user %s: %s", policyName, userName, err)
+	}
+
+	// append inline policy delete to rollback tasks
+	rbfunc := func(ctx context.Context) error {
+		return iamService.DeleteUserPolicy(ctx, &iam.DeleteUserPolicyInput{
+			UserName:   aws.String(userName),
+			PolicyName: aws.String(policyName),
+		})
+	}
+	rollBackTasks = append(rollBackTasks, rbfunc)
+
+	return rollBackTasks, nil
+}
+
 // CreateWebsiteBucketPolicy expects an acount, bucket name and the group name (without the bucket prefix).  It verifies the group
 // is one of our supported types and then generates a policy doc for the group and bucket.  Finally, it creates the group
 // and attaches the policy.  It returns a rollback function and will rollback itself if it encounters an error.

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/YaleSpinup/s3-api/common"
+	iamapi "github.com/YaleSpinup/s3-api/iam"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	log "github.com/sirupsen/logrus"
+)
+
+// groupSuffixToInline maps legacy group suffixes to inline policy suffixes
+var groupSuffixToInline = map[string]string{
+	"BktAdmGrp": "BktAdmPlc",
+	"BktRWGrp":  "BktRWPlc",
+	"BktROGrp":  "BktROPlc",
+	"WebAdmGrp": "WebAdmPlc",
+}
+
+// knownSuffixes lists all group suffixes we want to migrate
+var knownSuffixes = []string{"-BktAdmGrp", "-BktRWGrp", "-BktROGrp", "-WebAdmGrp"}
+
+func main() {
+	configFile := flag.String("config", "config/config.json", "Path to s3-api configuration file")
+	dryRun := flag.Bool("dry-run", false, "Preview changes without executing them")
+	targetAccount := flag.String("account", "", "Specific account name to migrate (default: all accounts)")
+	verbose := flag.Bool("verbose", false, "Enable debug logging")
+	flag.Parse()
+
+	if *verbose {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+
+	f, err := os.Open(*configFile)
+	if err != nil {
+		log.Fatalf("Unable to open config file: %s", err)
+	}
+	defer f.Close()
+
+	config, err := common.ReadConfig(bufio.NewReader(f))
+	if err != nil {
+		log.Fatalf("Unable to read config: %s", err)
+	}
+
+	if *dryRun {
+		log.Info("=== DRY RUN MODE — no changes will be made ===")
+	}
+
+	ctx := context.Background()
+
+	// Create the base AWS session with the config credentials
+	baseSess := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(config.Account.Akid, config.Account.Secret, ""),
+		Region:      aws.String(config.Account.Region),
+	}))
+
+	for accountName, accountId := range config.AccountsMap {
+		if *targetAccount != "" && accountName != *targetAccount {
+			continue
+		}
+
+		log.Infof("=== Migrating account: %s (ID: %s) ===", accountName, accountId)
+
+		// Assume the configured role into the target account (same pattern as cloudfront/server)
+		roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, config.Account.Role)
+		log.Infof("Assuming role: %s", roleArn)
+
+		assumedSess := session.Must(session.NewSession(&aws.Config{
+			Credentials: stscreds.NewCredentials(baseSess, roleArn, func(p *stscreds.AssumeRoleProvider) {
+				if config.Account.ExternalId != "" {
+					p.ExternalID = aws.String(config.Account.ExternalId)
+				}
+			}),
+			Region: aws.String(config.Account.Region),
+		}))
+
+		iamService := iamapi.NewSession(assumedSess, config.Account)
+
+		if err := migrateAccount(ctx, iamService, accountName, *dryRun); err != nil {
+			log.Errorf("Error migrating account %s: %s", accountName, err)
+		}
+	}
+
+	log.Info("=== Migration complete ===")
+}
+
+func migrateAccount(ctx context.Context, iamService iamapi.IAM, accountName string, dryRun bool) error {
+	// List all groups in the account
+	allGroups, err := iamService.ListGroups(ctx, &iam.ListGroupsInput{MaxItems: aws.Int64(1000)}, "")
+	if err != nil {
+		return fmt.Errorf("failed to list groups: %w", err)
+	}
+
+	// Filter to only groups matching our known suffixes
+	var matchingGroups []*iam.Group
+	for _, g := range allGroups {
+		groupName := aws.StringValue(g.GroupName)
+		if matchesKnownSuffix(groupName) {
+			matchingGroups = append(matchingGroups, g)
+		}
+	}
+
+	log.Infof("Found %d matching legacy groups out of %d total groups in account %s",
+		len(matchingGroups), len(allGroups), accountName)
+
+	if len(matchingGroups) == 0 {
+		log.Info("Nothing to migrate.")
+		return nil
+	}
+
+	var migrated, skipped, errored int
+	for _, group := range matchingGroups {
+		result, err := migrateGroup(ctx, iamService, group, dryRun)
+		if err != nil {
+			log.Errorf("Failed to migrate group %s: %s", aws.StringValue(group.GroupName), err)
+			errored++
+			continue
+		}
+		switch result {
+		case "migrated":
+			migrated++
+		case "skipped":
+			skipped++
+		}
+	}
+
+	log.Infof("Account %s summary: migrated=%d, skipped=%d, errors=%d", accountName, migrated, skipped, errored)
+	return nil
+}
+
+func migrateGroup(ctx context.Context, iamService iamapi.IAM, group *iam.Group, dryRun bool) (string, error) {
+	groupName := aws.StringValue(group.GroupName)
+	suffix := getGroupSuffix(groupName)
+	inlineSuffix := groupSuffixToInline[suffix]
+
+	if inlineSuffix == "" {
+		return "skipped", fmt.Errorf("unknown suffix for group %s", groupName)
+	}
+
+	log.Infof("Processing group: %s (suffix: %s → %s)", groupName, suffix, inlineSuffix)
+
+	// 1. Get users in the group
+	users, err := iamService.ListGroupUsers(ctx, &iam.GetGroupInput{GroupName: aws.String(groupName)})
+	if err != nil {
+		return "", fmt.Errorf("failed to list users in group %s: %w", groupName, err)
+	}
+
+	// 2. Get attached managed policies for this group
+	policies, err := iamService.ListGroupPolicies(ctx, &iam.ListAttachedGroupPoliciesInput{GroupName: aws.String(groupName)})
+	if err != nil {
+		return "", fmt.Errorf("failed to list policies for group %s: %w", groupName, err)
+	}
+
+	if len(policies) == 0 {
+		log.Warnf("Group %s has no attached policies — skipping", groupName)
+		return "skipped", nil
+	}
+
+	if len(users) == 0 {
+		log.Infof("Group %s has no users — cleaning up empty group", groupName)
+	}
+
+	// 3. Get the policy document from the first managed policy
+	policyArn := aws.StringValue(policies[0].PolicyArn)
+	policyDoc, err := getPolicyDocument(ctx, iamService, policyArn)
+	if err != nil {
+		return "", fmt.Errorf("failed to get policy document for group %s: %w", groupName, err)
+	}
+
+	// Derive inline policy name: replace group suffix with inline suffix
+	// e.g., "mybucket-BktAdmGrp" → "mybucket-BktAdmPlc"
+	inlinePolicyName := groupName[:len(groupName)-len(suffix)] + inlineSuffix
+
+	log.Debugf("Policy document for %s (%d bytes): %s", groupName, len(policyDoc), policyDoc)
+
+	// 4. For each user in the group, attach the inline policy
+	for _, user := range users {
+		userName := aws.StringValue(user.UserName)
+
+		if dryRun {
+			log.Infof("[DRY RUN] Would attach inline policy '%s' to user '%s' (from group %s)",
+				inlinePolicyName, userName, groupName)
+			log.Infof("[DRY RUN] Would remove user '%s' from group '%s'", userName, groupName)
+			continue
+		}
+
+		// Check if inline policy already exists on this user
+		existingPolicies, err := iamService.ListUserInlinePolicies(ctx, &iam.ListUserPoliciesInput{
+			UserName: aws.String(userName),
+		})
+		if err != nil {
+			log.Warnf("Failed to list inline policies for user %s: %s", userName, err)
+		}
+
+		alreadyExists := false
+		for _, p := range existingPolicies {
+			if aws.StringValue(p) == inlinePolicyName {
+				alreadyExists = true
+				break
+			}
+		}
+
+		if alreadyExists {
+			log.Infof("Inline policy '%s' already exists on user '%s' — skipping attachment", inlinePolicyName, userName)
+		} else {
+			// Attach inline policy
+			if err := iamService.PutUserPolicy(ctx, &iam.PutUserPolicyInput{
+				UserName:       aws.String(userName),
+				PolicyName:     aws.String(inlinePolicyName),
+				PolicyDocument: aws.String(policyDoc),
+			}); err != nil {
+				return "", fmt.Errorf("failed to put inline policy on user %s: %w", userName, err)
+			}
+			log.Infof("Attached inline policy '%s' to user '%s'", inlinePolicyName, userName)
+		}
+
+		// Remove user from group
+		if err := iamService.RemoveUserFromGroup(ctx, &iam.RemoveUserFromGroupInput{
+			UserName:  aws.String(userName),
+			GroupName: aws.String(groupName),
+		}); err != nil {
+			return "", fmt.Errorf("failed to remove user %s from group %s: %w", userName, groupName, err)
+		}
+		log.Infof("Removed user '%s' from group '%s'", userName, groupName)
+	}
+
+	// 5. Detach and delete managed policies from the group, then delete the group
+	if dryRun {
+		for _, p := range policies {
+			log.Infof("[DRY RUN] Would detach policy '%s' from group '%s'", aws.StringValue(p.PolicyArn), groupName)
+			log.Infof("[DRY RUN] Would delete managed policy '%s'", aws.StringValue(p.PolicyArn))
+		}
+		log.Infof("[DRY RUN] Would delete group '%s'", groupName)
+		return "migrated", nil
+	}
+
+	for _, p := range policies {
+		if err := iamService.DetachGroupPolicy(ctx, &iam.DetachGroupPolicyInput{
+			GroupName: aws.String(groupName),
+			PolicyArn: p.PolicyArn,
+		}); err != nil {
+			log.Warnf("Failed to detach policy %s from group %s: %s", aws.StringValue(p.PolicyArn), groupName, err)
+			continue
+		}
+		log.Infof("Detached policy '%s' from group '%s'", aws.StringValue(p.PolicyArn), groupName)
+
+		if err := iamService.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: p.PolicyArn}); err != nil {
+			log.Warnf("Failed to delete policy %s: %s", aws.StringValue(p.PolicyArn), err)
+		} else {
+			log.Infof("Deleted managed policy '%s'", aws.StringValue(p.PolicyArn))
+		}
+	}
+
+	if err := iamService.DeleteGroup(ctx, &iam.DeleteGroupInput{GroupName: aws.String(groupName)}); err != nil {
+		log.Warnf("Failed to delete group %s: %s", groupName, err)
+	} else {
+		log.Infof("Deleted group '%s'", groupName)
+	}
+
+	return "migrated", nil
+}
+
+func matchesKnownSuffix(groupName string) bool {
+	for _, suffix := range knownSuffixes {
+		if strings.HasSuffix(groupName, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func getGroupSuffix(groupName string) string {
+	for _, suffix := range knownSuffixes {
+		if strings.HasSuffix(groupName, suffix) {
+			return strings.TrimPrefix(suffix, "-")
+		}
+	}
+	return ""
+}
+
+// getPolicyDocument retrieves the policy document text from a managed policy ARN
+func getPolicyDocument(ctx context.Context, iamService iamapi.IAM, policyArn string) (string, error) {
+	policyDetail, err := iamService.Service.GetPolicyWithContext(ctx, &iam.GetPolicyInput{
+		PolicyArn: aws.String(policyArn),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get policy %s: %w", policyArn, err)
+	}
+
+	versionOutput, err := iamService.Service.GetPolicyVersionWithContext(ctx, &iam.GetPolicyVersionInput{
+		PolicyArn: aws.String(policyArn),
+		VersionId: policyDetail.Policy.DefaultVersionId,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get policy version for %s: %w", policyArn, err)
+	}
+
+	// AWS returns URL-encoded policy documents
+	doc, err := url.QueryUnescape(aws.StringValue(versionOutput.PolicyVersion.Document))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode policy document for %s: %w", policyArn, err)
+	}
+
+	return doc, nil
+}
+

--- a/iam/user.go
+++ b/iam/user.go
@@ -267,3 +267,108 @@ func (i *IAM) DetachUserPolicy(ctx context.Context, input *iam.DetachUserPolicyI
 
 	return nil
 }
+
+// PutUserPolicy attaches an inline policy document to an IAM user
+func (i *IAM) PutUserPolicy(ctx context.Context, input *iam.PutUserPolicyInput) error {
+	if input == nil || aws.StringValue(input.UserName) == "" || aws.StringValue(input.PolicyName) == "" || aws.StringValue(input.PolicyDocument) == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("putting inline policy %s for user %s", aws.StringValue(input.PolicyName), aws.StringValue(input.UserName))
+
+	_, err := i.Service.PutUserPolicyWithContext(ctx, input)
+	if err != nil {
+		return ErrCode("failed to put inline policy for user", err)
+	}
+
+	return nil
+}
+
+// DeleteUserPolicy removes an inline policy from an IAM user
+func (i *IAM) DeleteUserPolicy(ctx context.Context, input *iam.DeleteUserPolicyInput) error {
+	if input == nil || aws.StringValue(input.UserName) == "" || aws.StringValue(input.PolicyName) == "" {
+		return apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("deleting inline policy %s for user %s", aws.StringValue(input.PolicyName), aws.StringValue(input.UserName))
+
+	_, err := i.Service.DeleteUserPolicyWithContext(ctx, input)
+	if err != nil {
+		return ErrCode("failed to delete inline policy for user", err)
+	}
+
+	return nil
+}
+
+// GetUserPolicy retrieves an inline policy document for an IAM user
+func (i *IAM) GetUserPolicy(ctx context.Context, input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
+	if input == nil || aws.StringValue(input.UserName) == "" || aws.StringValue(input.PolicyName) == "" {
+		return nil, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("getting inline policy %s for user %s", aws.StringValue(input.PolicyName), aws.StringValue(input.UserName))
+
+	output, err := i.Service.GetUserPolicyWithContext(ctx, input)
+	if err != nil {
+		return nil, ErrCode("failed to get inline policy for user", err)
+	}
+
+	log.Debugf("get user policy output: %s", awsutil.Prettify(output))
+
+	return output, nil
+}
+
+// ListUserInlinePolicies lists the names of inline policies attached to an IAM user.
+// Note: This is distinct from ListUserPolicies which lists *attached managed* policies.
+func (i *IAM) ListUserInlinePolicies(ctx context.Context, input *iam.ListUserPoliciesInput) ([]*string, error) {
+	policyNames := []*string{}
+
+	if input == nil || aws.StringValue(input.UserName) == "" {
+		return policyNames, apierror.New(apierror.ErrBadRequest, "invalid input", nil)
+	}
+
+	log.Infof("listing inline policies for user %s", aws.StringValue(input.UserName))
+
+	truncated := true
+	for truncated {
+		output, err := i.Service.ListUserPoliciesWithContext(ctx, input)
+		if err != nil {
+			return nil, ErrCode("failed to list inline policies for user", err)
+		}
+		truncated = aws.BoolValue(output.IsTruncated)
+		policyNames = append(policyNames, output.PolicyNames...)
+		input.Marker = output.Marker
+	}
+
+	log.Debugf("got list of inline policies for user %s: %s", aws.StringValue(input.UserName), awsutil.Prettify(policyNames))
+
+	return policyNames, nil
+}
+
+// ListUsers lists all IAM users, optionally filtering by a name prefix.
+// If prefix is non-empty, only users whose UserName starts with the prefix are returned.
+func (i *IAM) ListUsers(ctx context.Context, prefix string) ([]*iam.User, error) {
+	var users []*iam.User
+
+	log.Infof("listing iam users with prefix '%s'", prefix)
+
+	input := &iam.ListUsersInput{}
+	truncated := true
+	for truncated {
+		output, err := i.Service.ListUsersWithContext(ctx, input)
+		if err != nil {
+			return nil, ErrCode("failed to list iam users", err)
+		}
+		truncated = aws.BoolValue(output.IsTruncated)
+		for _, u := range output.Users {
+			if prefix == "" || strings.HasPrefix(aws.StringValue(u.UserName), prefix) {
+				users = append(users, u)
+			}
+		}
+		input.Marker = output.Marker
+	}
+
+	log.Debugf("found %d users with prefix '%s'", len(users), prefix)
+
+	return users, nil
+}

--- a/iam/user_test.go
+++ b/iam/user_test.go
@@ -301,47 +301,6 @@ func (m *mockIAMClient) ListUsersWithContext(ctx context.Context, input *iam.Lis
 	return &iam.ListUsersOutput{Users: testUsers}, nil
 }
 
-func (m *mockIAMClient) PutUserPolicyWithContext(ctx context.Context, input *iam.PutUserPolicyInput, opts ...request.Option) (*iam.PutUserPolicyOutput, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &iam.PutUserPolicyOutput{}, nil
-}
-
-func (m *mockIAMClient) DeleteUserPolicyWithContext(ctx context.Context, input *iam.DeleteUserPolicyInput, opts ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &iam.DeleteUserPolicyOutput{}, nil
-}
-
-func (m *mockIAMClient) GetUserPolicyWithContext(ctx context.Context, input *iam.GetUserPolicyInput, opts ...request.Option) (*iam.GetUserPolicyOutput, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &iam.GetUserPolicyOutput{
-		UserName:       input.UserName,
-		PolicyName:     input.PolicyName,
-		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
-	}, nil
-}
-
-func (m *mockIAMClient) ListUserPoliciesWithContext(ctx context.Context, input *iam.ListUserPoliciesInput, opts ...request.Option) (*iam.ListUserPoliciesOutput, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &iam.ListUserPoliciesOutput{
-		PolicyNames: []*string{aws.String("policy1"), aws.String("policy2")},
-	}, nil
-}
-
-func (m *mockIAMClient) ListUsersWithContext(ctx context.Context, input *iam.ListUsersInput, opts ...request.Option) (*iam.ListUsersOutput, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &iam.ListUsersOutput{Users: testUsers}, nil
-}
-
 func TestGetUsernameFromBucket(t *testing.T) {
 	for _, set := range testBucketUserData {
 		bucket := set["bucket"]

--- a/iam/user_test.go
+++ b/iam/user_test.go
@@ -260,6 +260,88 @@ func (m *mockIAMClient) DetachUserPolicyWithContext(ctx context.Context, input *
 	return &iam.DetachUserPolicyOutput{}, nil
 }
 
+func (m *mockIAMClient) PutUserPolicyWithContext(ctx context.Context, input *iam.PutUserPolicyInput, opts ...request.Option) (*iam.PutUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.PutUserPolicyOutput{}, nil
+}
+
+func (m *mockIAMClient) DeleteUserPolicyWithContext(ctx context.Context, input *iam.DeleteUserPolicyInput, opts ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.DeleteUserPolicyOutput{}, nil
+}
+
+func (m *mockIAMClient) GetUserPolicyWithContext(ctx context.Context, input *iam.GetUserPolicyInput, opts ...request.Option) (*iam.GetUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.GetUserPolicyOutput{
+		UserName:       input.UserName,
+		PolicyName:     input.PolicyName,
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}, nil
+}
+
+func (m *mockIAMClient) ListUserPoliciesWithContext(ctx context.Context, input *iam.ListUserPoliciesInput, opts ...request.Option) (*iam.ListUserPoliciesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.ListUserPoliciesOutput{
+		PolicyNames: []*string{aws.String("policy1"), aws.String("policy2")},
+	}, nil
+}
+
+func (m *mockIAMClient) ListUsersWithContext(ctx context.Context, input *iam.ListUsersInput, opts ...request.Option) (*iam.ListUsersOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.ListUsersOutput{Users: testUsers}, nil
+}
+
+func (m *mockIAMClient) PutUserPolicyWithContext(ctx context.Context, input *iam.PutUserPolicyInput, opts ...request.Option) (*iam.PutUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.PutUserPolicyOutput{}, nil
+}
+
+func (m *mockIAMClient) DeleteUserPolicyWithContext(ctx context.Context, input *iam.DeleteUserPolicyInput, opts ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.DeleteUserPolicyOutput{}, nil
+}
+
+func (m *mockIAMClient) GetUserPolicyWithContext(ctx context.Context, input *iam.GetUserPolicyInput, opts ...request.Option) (*iam.GetUserPolicyOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.GetUserPolicyOutput{
+		UserName:       input.UserName,
+		PolicyName:     input.PolicyName,
+		PolicyDocument: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}, nil
+}
+
+func (m *mockIAMClient) ListUserPoliciesWithContext(ctx context.Context, input *iam.ListUserPoliciesInput, opts ...request.Option) (*iam.ListUserPoliciesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.ListUserPoliciesOutput{
+		PolicyNames: []*string{aws.String("policy1"), aws.String("policy2")},
+	}, nil
+}
+
+func (m *mockIAMClient) ListUsersWithContext(ctx context.Context, input *iam.ListUsersInput, opts ...request.Option) (*iam.ListUsersOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &iam.ListUsersOutput{Users: testUsers}, nil
+}
+
 func TestGetUsernameFromBucket(t *testing.T) {
 	for _, set := range testBucketUserData {
 		bucket := set["bucket"]


### PR DESCRIPTION
<h3 id="description-853" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Description</h3><h4 id="problem-851" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h4><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The Spinup S3 service creates up to 3 IAM Groups per bucket/website (<span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">BktAdmGrp</code></span>, <span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">BktRWGrp</code></span>, <span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">BktROGrp</code></span>). AWS enforces a hard limit of <strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">500 IAM Groups per account</strong>, and we are approaching that ceiling. This blocks further bucket/website creation.</p><h4 id="solution-775" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Solution</h4><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Replace the group-based access model with <strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">per-user inline IAM policies</strong>. Instead of creating groups at bucket/website provisioning time and adding users to those groups, policies are now generated and attached directly to each IAM user as inline policies when the user is created. This eliminates IAM Group consumption entirely for new resources.</p><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The system operates in a <strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">hybrid mode</strong> — all existing group-based users continue to work, and the codebase handles both models transparently.</p><h4 id="changes-688" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h4><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">iam/user.go</span></code></span></div></strong> (+105 lines) — New IAM SDK wrappers:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">PutUserPolicy</code></span><span> </span>— attach an inline policy document to a user</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">DeleteUserPolicy</code></span><span> </span>— remove an inline policy from a user</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">GetUserPolicy</code></span><span> </span>— retrieve an inline policy document</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">ListUserInlinePolicies</code></span><span> </span>— list inline policy names on a user</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">ListUsers</code></span><span> </span>— list IAM users filtered by a name prefix</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">FilterDuplicateUsers</code></span><span> </span>— deduplicate user lists from multiple sources</li></ul><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">iam/user_test.go</span></code></span></div></strong> (+82 lines) — Unit tests for the new SDK wrappers.</p><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">api/orchestration.go</span></code></span></div></strong> (+129 lines) — New orchestration helpers:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateBucketUserInlinePolicy</code></span><span> </span>— generates and attaches the correct bucket policy document (admin/read-write/read-only) as an inline policy, with rollback support</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateWebsiteUserInlinePolicy</code></span><span> </span>— same for website users, with path-aware policy generation</li></ul><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">api/handlers_buckets.go</span></code></span></div></strong> — Bucket lifecycle:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Create</strong>: Removed group/policy provisioning (no more<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateGroup</code></span>,<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreatePolicy</code></span>,<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">AttachGroupPolicy</code></span>). Bucket creation now only creates the S3 bucket and configures it.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Delete</strong>: Added inline-policy-based cleanup — discovers users by<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">{bucket}-</code></span><span> </span>prefix, deletes their inline policies, access keys, group memberships, managed policies, and the users themselves. Legacy group cleanup is preserved.</li></ul><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">api/handlers_website.go</span></code></span></div></strong> — Website lifecycle:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Create</strong>: Removed provisioning of both<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">BktAdmGrp</code></span>/<span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">BktAdmPlc</code></span><span> </span>and<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">WebAdmGrp</code></span>/<span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">WebAdmPlc</code></span><span> </span>group/policy pairs (~130 lines removed). Response no longer includes<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">Policies</code></span><span> </span>or<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">Groups</code></span><span> </span>fields.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Delete</strong>: Added inline-policy-based cleanup identical to bucket delete. Legacy group cleanup preserved.</li></ul><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">api/handlers_users.go</span></code></span></div></strong> — Bucket user operations:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Create</strong>: Replaced<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">GetGroup</code></span><span> </span>→<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateBucketGroupPolicy</code></span><span> </span>→<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">AddUserToGroup</code></span><span> </span>flow with<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateBucketUserInlinePolicy</code></span>.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Delete</strong>: Added inline policy cleanup before managed policy cleanup.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">List</strong>: Now discovers users via both legacy group membership AND prefix-based listing (<span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">{bucket}-</code></span>), with deduplication.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Show</strong>: Response now includes<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">InlinePolicies</code></span><span> </span>field alongside<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">Groups</code></span>.</li></ul><p class="augment-markdown-paragraph svelte-1czxcab" style="box-sizing: border-box; white-space: pre-line; margin-block: 8px; padding-inline: 4px; font-size: 12px; line-height: 16px; word-break: break-word; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;"><div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;">api/handlers_website_users.go</span></code></span></div></strong> — Website user operations:</p><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Create</strong>: Replaced group-based flow with<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">CreateWebsiteUserInlinePolicy</code></span>. Removed<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">WebAdmGrp</code></span><span> </span>auto-assignment for root-path admins.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;"><strong style="box-sizing: border-box; color: rgb(237, 238, 240); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-weight: 700;">Show</strong>: Added prefix-based user discovery and<span> </span><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline;">InlinePolicies</code></span><span> </span>in the response. Added deduplication.</li></ul><h4 id="naming-convention-300" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Naming Convention</h4>
Access Level | Legacy Group | Legacy Policy | New Inline Policy
-- | -- | -- | --
Admin | {name}-BktAdmGrp | {name}-BktAdmPlc (managed) | {name}-BktAdmPlc (inline)
Read-Write | {name}-BktRWGrp | {name}-BktRWPlc (managed) | {name}-BktRWPlc (inline)
Read-Only | {name}-BktROGrp | {name}-BktROPlc (managed) | {name}-BktROPlc (inline)

<h4 id="backward-compatibility-267" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Backward Compatibility</h4><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;">All handlers support both group-based (legacy) and inline-policy (new) users simultaneously.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;">No migration is required at deploy time. Existing resources continue to function.</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;">A future migration script can retroactively convert group-based users to inline policies to reclaim group slots.</li></ul><h4 id="testing-239" style="box-sizing: border-box; margin-block: 12px; font-weight: 700; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; padding-inline: 4px; color: rgb(237, 238, 240); font-size: 12px; line-height: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing</h4><ul style="box-sizing: border-box; padding-inline-start: 32px; font-size: 12px; line-height: 16px; display: flex; flex-direction: column; gap: 4px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;">Unit tests added for new IAM wrappers (<div class="c-chat-codespan svelte-12i2pat c-chat-codespan--linkable" style="box-sizing: border-box; display: contents;"><span style="box-sizing: border-box;"><code class="markdown-codespan svelte-44cwx9" style="font-family: Menlo, Monaco, &quot;Courier New&quot;, monospace; color: rgb(112, 184, 255); background-color: rgb(24, 24, 24); padding: 1px 3px; border-radius: 2px; box-sizing: border-box; --codepsan-border-color: #d8f4f609; --codepsan-bg-color: #181818; --codespan-fg-color: #70b8ff; padding-inline: 2px; font-size: 0.9em; border-color: rgba(216, 244, 246, 0.035); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; word-break: break-all; display: inline; cursor: pointer; user-select: all;"><span class="c-chat-codespan__content svelte-12i2pat" role="button" tabindex="0" style="box-sizing: border-box; position: relative;"><span> </span>iam/user_test.go</span></code></span></div>).</li><li style="box-sizing: border-box; font-size: 12px; line-height: 16px;">Manual testing recommended for create/delete/list/show flows for both buckets and websites.</li></ul>